### PR TITLE
style: update chain label theme

### DIFF
--- a/src/components/TransactionConfirmationModal/index.tsx
+++ b/src/components/TransactionConfirmationModal/index.tsx
@@ -233,7 +233,7 @@ function L2Content({
             <Badge>
               <RowFixed>
                 <StyledLogo src={info.logoUrl} style={{ margin: '0 8px 0 0' }} />
-                {info.label}
+                <ThemedText.SubHeaderSmall>{info.label}</ThemedText.SubHeaderSmall>
               </RowFixed>
             </Badge>
             <CloseIcon onClick={onDismiss} />


### PR DESCRIPTION
# WHAT

Chain label is not wrapped by ```ThemedText``` in ```TransactionConfirmationModal```. That's why color of theme is not changing.

<img width="528" alt="image" src="https://github.com/taikoxyz/uniswap-interface/assets/73793382/a4b2cb44-3030-4aca-b05a-3aeff64c4c36">

# FIX

Wrapped chain label by ```ThemedText``` in ```TransactionConfirmationModal```.