### PR TITLE
fix: enable BrowserRouter for Taiko DEX domains

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -23,11 +23,16 @@ export function isAppUniswapStagingOrg({ hostname }: { hostname: string }): bool
   return hostname === 'app.corn-staging.com'
 }
 
+export function isTaikoDex({ hostname }: { hostname: string }): boolean {
+  return hostname === 'swap.taiko.xyz' || hostname === 'swap.hoodi.taiko.xyz'
+}
+
 export function isBrowserRouterEnabled(): boolean {
   if (isProductionEnv()) {
     if (
       isAppUniswapOrg(window.location) ||
       isAppUniswapStagingOrg(window.location) ||
+      isTaikoDex(window.location) ||
       isLocalhost(window.location) // cypress tests
     ) {
       return true


### PR DESCRIPTION
## Summary
- Fixes 404 errors on `/terms-of-service` and `/privacy-policy` routes
- Adds `swap.taiko.xyz` and `swap.hoodi.taiko.xyz` to BrowserRouter whitelist
- Enables clean URLs without hash routing (`/#/`) for Taiko DEX production domains

## Problem
The app was using HashRouter in production for Taiko domains because they weren't in the BrowserRouter whitelist. This caused routes like `/terms-of-service` and `/privacy-policy` to 404, requiring users to access them via `/#/terms-of-service` instead.

## Solution
Added `isTaikoDex()` function to check for Taiko DEX domains and included it in the `isBrowserRouterEnabled()` check. Now both production Taiko domains will use BrowserRouter, making all routes work with standard URL paths.