### PR TITLE
fix: enable BrowserRouter for Taiko DEX domains and use React Router Links

### DIFF
--- a/src/components/PrivacyPolicy/index.tsx
+++ b/src/components/PrivacyPolicy/index.tsx
@@ -5,6 +5,7 @@ import Card, { DarkGrayCard } from 'components/Card'
 import Row, { AutoRow, RowBetween } from 'components/Row'
 import { useEffect, useRef } from 'react'
 import { ArrowDown, Info, X } from 'react-feather'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { ExternalLink, ThemedText } from 'theme'
 import { isMobile } from 'utils/userAgent'
@@ -141,7 +142,7 @@ function PrivacyPolicy() {
       <AutoColumn gap="16px">
         <AutoColumn gap="sm" style={{ width: '100%' }}>
           <StyledExternalCard>
-            <ExternalLink href="/terms-of-service">
+            <Link to="/terms-of-service" style={{ textDecoration: 'none' }}>
               <RowBetween>
                 <AutoRow gap="4px">
                   <Info size={20} />
@@ -151,10 +152,10 @@ function PrivacyPolicy() {
                 </AutoRow>
                 <StyledLinkOut size={20} />
               </RowBetween>
-            </ExternalLink>
+            </Link>
           </StyledExternalCard>
           <StyledExternalCard>
-            <ExternalLink href="/privacy-policy">
+            <Link to="/privacy-policy" style={{ textDecoration: 'none' }}>
               <RowBetween>
                 <AutoRow gap="4px">
                   <Info size={20} />
@@ -164,7 +165,7 @@ function PrivacyPolicy() {
                 </AutoRow>
                 <StyledLinkOut size={20} />
               </RowBetween>
-            </ExternalLink>
+            </Link>
           </StyledExternalCard>
         </AutoColumn>
         <ThemedText.DeprecatedMain fontSize={14}>

--- a/src/components/WalletModal/PrivacyPolicyNotice.tsx
+++ b/src/components/WalletModal/PrivacyPolicyNotice.tsx
@@ -1,10 +1,12 @@
 import { Trans } from '@lingui/macro'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
-import { ExternalLink, ThemedText } from 'theme'
+import { ThemedText } from 'theme'
 
-const StyledLink = styled(ExternalLink)`
+const StyledLink = styled(Link)`
   font-weight: 535;
   color: ${({ theme }) => theme.neutral2};
+  text-decoration: none;
 `
 
 const LastUpdatedText = styled.span`
@@ -17,11 +19,11 @@ export default function PrivacyPolicyNotice() {
   return (
     <ThemedText.BodySmall color="neutral2">
       <Trans>By connecting a wallet, you agree to Taiko DEX&apos;s</Trans>{' '}
-      <StyledLink href="/terms-of-service">
+      <StyledLink to="/terms-of-service">
         <Trans>Terms of Service</Trans>{' '}
       </StyledLink>
       <Trans>and consent to its</Trans>{' '}
-      <StyledLink href="/privacy-policy">
+      <StyledLink to="/privacy-policy">
         <Trans>Privacy Policy.</Trans>
       </StyledLink>
       <LastUpdatedText>


### PR DESCRIPTION
## Summary
- Fixes 404 errors on `/terms-of-service` and `/privacy-policy` routes
- Adds `swap.taiko.xyz` and `swap.hoodi.taiko.xyz` to BrowserRouter whitelist
- Replaces `ExternalLink` with React Router `Link` for internal route navigation
- Enables clean URLs without hash routing (`/#/`) for Taiko DEX production domains

## Problem
The app was using HashRouter in production for Taiko domains because they weren't in the BrowserRouter whitelist. Additionally, some components used `ExternalLink` with `href` attributes for internal routes, causing full page reloads instead of client-side navigation. This caused routes like `/terms-of-service` and `/privacy-policy` to 404.

## Solution
1. Added `isTaikoDex()` function to check for Taiko DEX domains and included it in the `isBrowserRouterEnabled()` check
2. Replaced `ExternalLink` with `Link` from react-router-dom in:
   - `PrivacyPolicyNotice` component
   - `PrivacyPolicy` modal component

Now both production Taiko domains will use BrowserRouter with proper client-side navigation, making all routes work with standard URL paths.