### PR TITLE
fix: Convert timestamps to Date objects for xScale

### DIFF
--- a/src/pages/PoolDetails/PoolChart.tsx
+++ b/src/pages/PoolDetails/PoolChart.tsx
@@ -66,7 +66,7 @@ export function PoolChart({ data, width, height, chartType }: PoolChartProps) {
   const xScale = useMemo(
     () =>
       scaleTime({
-        domain: [Math.min(...data.map((d) => d.timestamp)), Math.max(...data.map((d) => d.timestamp))],
+        domain: [new Date(Math.min(...data.map((d) => d.timestamp)) * 1000), new Date(Math.max(...data.map((d) => d.timestamp)) * 1000)],
         range: [0, innerWidth],
       }),
     [data, innerWidth]
@@ -80,7 +80,7 @@ export function PoolChart({ data, width, height, chartType }: PoolChartProps) {
     })
   }, [data, innerHeight, chartType])
 
-  const getX = useCallback((d: ChartDataPoint) => xScale(d.timestamp) || 0, [xScale])
+  const getX = useCallback((d: ChartDataPoint) => xScale(new Data(d.timestamp * 1000)) || 0, [xScale])
   const getY = useCallback(
     (d: ChartDataPoint) => yScale(chartType === 'VOLUME' ? d.volumeUSD : d.tvlUSD) || 0,
     [yScale, chartType]

--- a/src/pages/PoolDetails/PoolChart.tsx
+++ b/src/pages/PoolDetails/PoolChart.tsx
@@ -80,7 +80,7 @@ export function PoolChart({ data, width, height, chartType }: PoolChartProps) {
     })
   }, [data, innerHeight, chartType])
 
-  const getX = useCallback((d: ChartDataPoint) => xScale(new Data(d.timestamp * 1000)) || 0, [xScale])
+  const getX = useCallback((d: ChartDataPoint) => xScale(new Date(d.timestamp * 1000)) || 0, [xScale])
   const getY = useCallback(
     (d: ChartDataPoint) => yScale(chartType === 'VOLUME' ? d.volumeUSD : d.tvlUSD) || 0,
     [yScale, chartType]


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description
Fix pool chart time axis to use `Date` objects (ms) instead of unix seconds, so x-axis tick labels match tooltip dates and render correctly across time ranges.

<!-- Delete this section if your change does not affect UI. -->
## Screen capture

<img width="1280" height="392" alt="image" src="https://github.com/user-attachments/assets/78f136fc-0123-40aa-ae78-423765ee3296" />

## Test plan

<!-- Delete this section if your change is not a bug fix. -->
### Reproducing the error

<!-- Include steps to reproduce the bug. -->
1. Open any pool chart (e.g. Volume/TVL) - https://swap.taiko.xyz/pools/taiko/0xdf2de6b0622fa3d5d6c0e0920661f18432bdc8eb

#### Devices
<!-- If applicable, include different devices and screen sizes that may be affected, and how you've tested them. -->

- Desktop browser (Chrome)
