### PR TITLE
Fix text overflow in Explore tab stats cards and token/pool tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ cypress/screenshots
 # Git worktrees (Crystal)
 /worktrees/
 /worktree-*/
+.gstack/

--- a/src/components/Tokens/TokenTable/TokenRow.tsx
+++ b/src/components/Tokens/TokenTable/TokenRow.tsx
@@ -110,6 +110,10 @@ const ClickableContent = styled.div<{ gap?: number }>`
   color: ${({ theme }) => theme.neutral1};
   align-items: center;
   cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 `
 const ClickableName = styled(ClickableContent)`
   gap: 8px;
@@ -148,6 +152,7 @@ const ListNumberCell = styled(Cell)<{ header: boolean }>`
 const DataCell = styled(Cell)<{ sortable: boolean }>`
   justify-content: flex-end;
   min-width: 80px;
+  overflow: hidden;
   user-select: ${({ sortable }) => (sortable ? 'none' : 'unset')};
   transition: ${({
     theme: {

--- a/src/graphql/taiko/TaikoTopPools.ts
+++ b/src/graphql/taiko/TaikoTopPools.ts
@@ -131,8 +131,12 @@ export function useTopPoolsTaiko(
 
     return data.pools.map((pool): NormalizedTaikoPool => {
       const tvlUSD = parseFloat(pool.totalValueLockedUSD)
-      const volumeUSD = parseFloat(pool.volumeUSD)
-      const feesUSD = parseFloat(pool.feesUSD)
+      // Cap corrupted pool volumes: USDC/TAIKO 0.3% pool has $8.1e+32 phantom volume
+      // from two bad subgraph events. TODO: Remove after subgraph reindex.
+      const rawVolumeUSD = parseFloat(pool.volumeUSD)
+      const rawFeesUSD = parseFloat(pool.feesUSD)
+      const volumeUSD = rawVolumeUSD > 1e9 ? 0 : rawVolumeUSD
+      const feesUSD = rawFeesUSD > 1e9 ? 0 : rawFeesUSD
       const feeTier = parseInt(pool.feeTier)
 
       // Calculate APR: (annual fees / TVL) * 100
@@ -171,19 +175,36 @@ export function useTopPoolsTaiko(
 
 /**
  * Query for protocol-wide TVL stats
+ *
+ * Fetches both factory totals and individual pool data. Factory cumulative
+ * volumeUSD/feesUSD are corrupted by two bad swap events (Feb 17 & Mar 2 2026)
+ * on the USDC/TAIKO 0.3% pool that recorded ~$8.1e+32 in phantom volume.
+ * We compute corrected totals from individual pool volumes, capping each pool
+ * at a reasonable maximum. TVL, txCount, and poolCount are unaffected.
+ *
+ * TODO: Remove this workaround after the subgraph is reindexed with the
+ * volume sanity cap fix (taikoxyz/uniswap-v3-subgraph).
  */
 const TAIKO_PROTOCOL_STATS_QUERY = gql`
   query TaikoProtocolStats {
     factories(first: 1) {
       id
-      totalVolumeUSD
       totalValueLockedUSD
-      totalFeesUSD
       txCount
       poolCount
     }
+    pools(first: 100) {
+      volumeUSD
+      feesUSD
+    }
   }
 `
+
+// Per-pool volume cap: any pool reporting more than $100M cumulative volume
+// is almost certainly corrupted given Taiko's current liquidity (~$5.6M TVL).
+// Corrupted values are zeroed (not capped) since the real value can't be
+// recovered from the pool entity — it requires summing daily data.
+const MAX_POOL_VOLUME_USD = 1e8
 
 export interface TaikoProtocolStats {
   totalVolumeUSD: number
@@ -207,11 +228,13 @@ export function useProtocolStatsTaiko(chainId: number): UseProtocolStatsTaikoRes
 
   const { data, loading, error } = useQuery<{
     factories: Array<{
-      totalVolumeUSD: string
       totalValueLockedUSD: string
-      totalFeesUSD: string
       txCount: string
       poolCount: string
+    }>
+    pools: Array<{
+      volumeUSD: string
+      feesUSD: string
     }>
   }>(TAIKO_PROTOCOL_STATS_QUERY, {
     client,
@@ -222,10 +245,22 @@ export function useProtocolStatsTaiko(chainId: number): UseProtocolStatsTaikoRes
     if (!data?.factories?.[0]) return undefined
 
     const factory = data.factories[0]
+
+    // Sum volume/fees from individual pools, zeroing corrupted entries
+    const totalVolumeUSD = (data.pools || []).reduce((sum, pool) => {
+      const vol = parseFloat(pool.volumeUSD)
+      return sum + (vol > MAX_POOL_VOLUME_USD ? 0 : vol)
+    }, 0)
+
+    const totalFeesUSD = (data.pools || []).reduce((sum, pool) => {
+      const fees = parseFloat(pool.feesUSD)
+      return sum + (fees > MAX_POOL_VOLUME_USD ? 0 : fees)
+    }, 0)
+
     return {
-      totalVolumeUSD: parseFloat(factory.totalVolumeUSD),
+      totalVolumeUSD,
       totalValueLockedUSD: parseFloat(factory.totalValueLockedUSD),
-      totalFeesUSD: parseFloat(factory.totalFeesUSD),
+      totalFeesUSD,
       txCount: parseInt(factory.txCount),
       poolCount: parseInt(factory.poolCount),
     }

--- a/src/graphql/taiko/TaikoTopTokens.ts
+++ b/src/graphql/taiko/TaikoTopTokens.ts
@@ -269,7 +269,11 @@ function normalizeTokens(
   const chainName = chainId === TAIKO_MAINNET_CHAIN_ID ? 'TAIKO' : 'TAIKO_HOODI'
 
   return tokens.map((token): NormalizedTaikoToken => {
-    const volumeUSD = parseFloat(token.volumeUSD)
+    // Cap volume: token-level volumeUSD is corrupted for USDC and TAIKO due to
+    // bad subgraph data (two swaps with phantom $8.1e+32 volume).
+    // TODO: Remove after subgraph reindex.
+    const rawVolumeUSD = parseFloat(token.volumeUSD)
+    const volumeUSD = rawVolumeUSD > 1e9 ? 0 : rawVolumeUSD
     const tvlUSD = parseFloat(token.totalValueLockedUSD)
     const derivedETH = parseFloat(token.derivedETH || '0')
     const priceUSD = derivedETH * ethPriceUSD

--- a/src/pages/Explore/PoolsTable.tsx
+++ b/src/pages/Explore/PoolsTable.tsx
@@ -20,6 +20,7 @@ const TableContainer = styled.div`
 const Table = styled.table`
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 `
 
 const TableHeader = styled.thead`
@@ -55,6 +56,10 @@ const TableRow = styled.tr`
 const TableCell = styled.td`
   padding: 16px;
   font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
 `
 
 const PoolCell = styled(TableCell)`

--- a/src/pages/Explore/PoolsTable.tsx
+++ b/src/pages/Explore/PoolsTable.tsx
@@ -102,17 +102,21 @@ const LoadingContainer = styled(NoPoolsContainer)``
 type SortField = 'tvl' | 'volume' | 'fees' | 'apr'
 
 function formatNumber(value: number): string {
-  if (value >= 1_000_000) {
-    return `$${(value / 1_000_000).toFixed(2)}M`
-  }
-  if (value >= 1_000) {
-    return `$${(value / 1_000).toFixed(2)}K`
-  }
-  return `$${value.toFixed(2)}`
+  if (value === 0) return '$0.00'
+  if (value >= 1e15) return '>$999T'
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    notation: 'compact',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
 }
 
 function formatPercent(value: number): string {
   if (value === 0) return '-'
+  if (value >= 1e10) return '>999%'
   return `${value.toFixed(2)}%`
 }
 
@@ -291,7 +295,7 @@ export function PoolsTable() {
               <TableCell>{formatNumber(pool.tvlUSD)}</TableCell>
               <TableCell>{formatPercent(pool.apr || 0)}</TableCell>
               <TableCell>{formatNumber(pool.volumeUSD)}</TableCell>
-              <TableCell>{pool.tvlUSD > 0 ? `${((pool.volumeUSD / pool.tvlUSD) * 100).toFixed(2)}%` : '-'}</TableCell>
+              <TableCell>{pool.tvlUSD > 0 ? formatPercent((pool.volumeUSD / pool.tvlUSD) * 100) : '-'}</TableCell>
             </TableRow>
           ))}
         </tbody>

--- a/src/pages/Explore/ProtocolStats.tsx
+++ b/src/pages/Explore/ProtocolStats.tsx
@@ -46,17 +46,16 @@ const StatChange = styled.span<{ $positive?: boolean }>`
 
 function formatNumber(value: number | undefined): string {
   if (value === undefined) return '-'
+  if (value === 0) return '$0.00'
+  if (value >= 1e15) return '>$999T'
 
-  if (value >= 1_000_000_000) {
-    return `$${(value / 1_000_000_000).toFixed(2)}B`
-  }
-  if (value >= 1_000_000) {
-    return `$${(value / 1_000_000).toFixed(2)}M`
-  }
-  if (value >= 1_000) {
-    return `$${(value / 1_000).toFixed(2)}K`
-  }
-  return `$${value.toFixed(2)}`
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    notation: 'compact',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value)
 }
 
 function formatCount(value: number | undefined): string {

--- a/src/pages/Explore/ProtocolStats.tsx
+++ b/src/pages/Explore/ProtocolStats.tsx
@@ -33,6 +33,9 @@ const StatLabel = styled(ThemedText.BodySecondary)`
 const StatValue = styled(ThemedText.HeadlineLarge)`
   font-size: 28px;
   font-weight: 535;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 
 const StatChange = styled.span<{ $positive?: boolean }>`

--- a/src/utils/formatNumbers.ts
+++ b/src/utils/formatNumbers.ts
@@ -256,7 +256,12 @@ const fiatTokenStatsFormatter: FormatterRule[] = [
   { exact: 0, hardCodedInput: { hardcodedOutput: '-' }, formatterOptions: ONE_SIG_FIG_CURRENCY },
   { upperBound: 0.01, hardCodedInput: { input: 0.01, prefix: '<' }, formatterOptions: TWO_DECIMALS_CURRENCY },
   { upperBound: 1000, formatterOptions: TWO_DECIMALS_CURRENCY },
-  { upperBound: Infinity, formatterOptions: SHORTHAND_CURRENCY_ONE_DECIMAL },
+  { upperBound: 1e15, formatterOptions: SHORTHAND_CURRENCY_ONE_DECIMAL },
+  {
+    upperBound: Infinity,
+    hardCodedInput: { input: 999_000_000_000_000, prefix: '>' },
+    formatterOptions: SHORTHAND_CURRENCY_ONE_DECIMAL,
+  },
 ]
 
 const fiatGasPriceFormatter: FormatterRule[] = [


### PR DESCRIPTION
## Summary

Fixes the Explore tab's broken number display and underlying data corruption issues.

### Commit 1: CSS overflow handling
- Adds `overflow: hidden; text-overflow: ellipsis` to stat cards, token table cells, and pool table cells to prevent long numbers from breaking layout.

### Commit 2: Number formatting
- Replaces hand-rolled `formatNumber` functions (which produced scientific notation on large numbers) with `Intl.NumberFormat` using compact notation (`$5.62M`, `$32.0M`).
- Adds `>$999T` cap for values >= 1e15 across stat cards, pool table, and token table formatters.
- Fixes `formatPercent` to cap at `>999%` for corrupted APR/vol-TVL ratios.

### Commit 3: Subgraph data corruption hotfix
Two swap events on the USDC/TAIKO 0.3% pool (Feb 17 & Mar 2 2026) recorded ~$8.1e+32 in phantom volume due to a transient `derivedETH` price spike in the subgraph. This corrupted cumulative `volumeUSD` and `feesUSD` on the pool, token, and factory entities. TVL, prices, and daily data are unaffected.

**Protocol stats**: Instead of reading the corrupted `factory.totalVolumeUSD`, we now query individual pool volumes and sum them, zeroing any pool exceeding $100M (corrupted pool is $8.1e+32, largest clean pool is $22.75M).

**Token table**: Any token with `volumeUSD` > $1B is zeroed. Affects USDC and TAIKO (both route through the corrupted pool).

**Pool table**: Any pool with `volumeUSD` or `feesUSD` > $1B is zeroed.

### Known accounting gap

Total volume shows **$32M** instead of the real **~$55M**. The corrupted pool's legitimate ~$23M volume can't be recovered from its entity (the cumulative field is $8.1e+32 and JS floating point can't extract the real value). This resolves automatically after the subgraph is reindexed — see taikoxyz/uniswap-v3-subgraph#6 for the root cause fix. All hotfix code is marked with `TODO: Remove after subgraph reindex`.

## Test plan
- [x] Stat cards show reasonable values ($32.03M volume, $5.62M TVL, $96.09K fees)
- [x] Token table: WETH volume correct ($32.0M), TAIKO/USDC show "-" (zeroed)
- [x] Pool table: corrupted pool shows $0.00 volume, clean pools unaffected
- [x] Swap page unaffected
- [x] No scientific notation anywhere in Explore tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)