### PR TITLE
fix: disable Uniswap screening worker to fix CORS on swap.taiko.xyz

### DIFF
--- a/src/components/TopLevelModals/index.tsx
+++ b/src/components/TopLevelModals/index.tsx
@@ -1,11 +1,8 @@
-import { useWeb3React } from '@web3-react/core'
 import { OffchainActivityModal } from 'components/AccountDrawer/MiniPortfolio/Activity/OffchainActivityModal'
 import UniwalletModal from 'components/AccountDrawer/UniwalletModal'
 import AirdropModal from 'components/AirdropModal'
 import BaseAnnouncementBanner from 'components/Banner/BaseAnnouncementBanner'
 import AddressClaimModal from 'components/claim/AddressClaimModal'
-import ConnectedAccountBlocked from 'components/ConnectedAccountBlocked'
-import useAccountRiskCheck from 'hooks/useAccountRiskCheck'
 import Bag from 'nft/components/bag/Bag'
 import TransactionCompleteModal from 'nft/components/collection/TransactionCompleteModal'
 import { useModalIsOpen, useToggleModal } from 'state/application/hooks'
@@ -14,15 +11,10 @@ import { ApplicationModal } from 'state/application/reducer'
 export default function TopLevelModals() {
   const addressClaimOpen = useModalIsOpen(ApplicationModal.ADDRESS_CLAIM)
   const addressClaimToggle = useToggleModal(ApplicationModal.ADDRESS_CLAIM)
-  const blockedAccountModalOpen = useModalIsOpen(ApplicationModal.BLOCKED_ACCOUNT)
-  const { account } = useWeb3React()
-  useAccountRiskCheck(account)
-  const accountBlocked = Boolean(blockedAccountModalOpen && account)
 
   return (
     <>
       <AddressClaimModal isOpen={addressClaimOpen} onDismiss={addressClaimToggle} />
-      <ConnectedAccountBlocked account={account} isOpen={accountBlocked} />
       <Bag />
       <UniwalletModal />
       <BaseAnnouncementBanner />


### PR DESCRIPTION
<!-- Your PR title must follow conventional commits: https://github.com/Uniswap/interface#pr-title -->

## Description

Removes the call to `screening-worker.uniswap.workers.dev` from `TopLevelModals`, which caused CORS errors on `swap.taiko.xyz` because Uniswap's worker only permits requests from their own origin (`app.uniswap.org`). Also removes the `ConnectedAccountBlocked` modal and related state that depended on the screening response — Taiko has no obligation to enforce Uniswap Labs' compliance screening.

Note: the Amplitude `Invalid API key` console error is a separate issue requiring removal of `REACT_APP_AMPLITUDE_API_KEY` from the hosting platform's environment variables (no code change needed — the guard in `src/tracing/index.ts` already skips initialization when the key is absent).

## Test plan

### Reproducing the error
1. Visit https://swap.taiko.xyz/pools
2. Open DevTools → Console → observe CORS error from `screening-worker.uniswap.workers.dev`

### QA (ie manual testing)
- [x] Connect a wallet on swap.taiko.xyz — no CORS errors, no blocked account modal appears
- [x] Swap and pool flows are unaffected

### Automated testing
- [x] Unit test N/A
- [x] Integration/E2E test N/A