### PR TITLE
fix: repair Taiko swap review flow and activity feed

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Activity/useTaikoActivityAdapter.test.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/useTaikoActivityAdapter.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from 'test-utils/render'
+
+import { useTaikoActivityAdapter } from './useTaikoActivityAdapter'
+
+const TAIKO_MAINNET_CHAIN_ID = 167000
+
+jest.mock('@web3-react/core', () => ({
+  useWeb3React: () => ({ chainId: TAIKO_MAINNET_CHAIN_ID }),
+}))
+
+const mockUseTaikoActivity = jest.fn()
+jest.mock('graphql/taiko/TaikoActivity', () => ({
+  useTaikoActivity: (...args: unknown[]) => mockUseTaikoActivity(...args),
+}))
+
+const WETH = { id: '0xA51894664A773981C6C112C43ce576f315d5b1B6', symbol: 'WETH', name: 'Wrapped Ether', decimals: '18' }
+const TAIKO = { id: '0xA9d23408b9bA935c230493c40C73824Df71A0975', symbol: 'TAIKO', name: 'Taiko Token', decimals: '18' }
+
+function mockSwap(amount0: string, amount1: string) {
+  return {
+    swaps: [
+      {
+        id: 'swap-1',
+        timestamp: '1000',
+        sender: '0xabc',
+        origin: '0xabc',
+        amount0,
+        amount1,
+        amountUSD: '100',
+        pool: { id: '0xpool', token0: WETH, token1: TAIKO },
+        transaction: { id: '0xhash', blockNumber: '1', timestamp: '1000' },
+      },
+    ],
+    mints: [],
+    burns: [],
+    collects: [],
+  }
+}
+
+describe('useTaikoActivityAdapter swap direction', () => {
+  beforeEach(() => mockUseTaikoActivity.mockReset())
+
+  // Pool is token0=WETH, token1=TAIKO. A TAIKO->WETH trade has amount1 (TAIKO) > 0 (sold in)
+  // and amount0 (WETH) < 0 (bought out). It must read "Swap TAIKO for WETH", not "WETH for TAIKO".
+  it('labels a TAIKO->WETH swap in the user trade direction', () => {
+    mockUseTaikoActivity.mockReturnValue({ activities: mockSwap('-0.1', '2051.75'), loading: false, refetch: jest.fn() })
+    const { result } = renderHook(() => useTaikoActivityAdapter('0xabc'))
+    const activity = result.current.activities?.[0]
+    expect(activity?.title).toBe('Swap TAIKO for WETH')
+    expect(activity?.descriptor).toBe('2051.75 TAIKO → 0.1 WETH')
+    expect(activity?.currencies?.[0]?.symbol).toBe('TAIKO')
+    expect(activity?.currencies?.[1]?.symbol).toBe('WETH')
+  })
+
+  // The opposite direction (WETH->TAIKO): amount0 (WETH) > 0 sold in, amount1 (TAIKO) < 0 bought out.
+  it('labels a WETH->TAIKO swap in the user trade direction', () => {
+    mockUseTaikoActivity.mockReturnValue({ activities: mockSwap('0.1', '-2051.75'), loading: false, refetch: jest.fn() })
+    const { result } = renderHook(() => useTaikoActivityAdapter('0xabc'))
+    const activity = result.current.activities?.[0]
+    expect(activity?.title).toBe('Swap WETH for TAIKO')
+    expect(activity?.descriptor).toBe('0.1 WETH → 2051.75 TAIKO')
+    expect(activity?.currencies?.[0]?.symbol).toBe('WETH')
+    expect(activity?.currencies?.[1]?.symbol).toBe('TAIKO')
+  })
+})

--- a/src/components/AccountDrawer/MiniPortfolio/Activity/useTaikoActivityAdapter.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Activity/useTaikoActivityAdapter.ts
@@ -42,6 +42,21 @@ export function useTaikoActivityAdapter(account: string): {
         swap.pool.token1.name
       )
 
+      // Uniswap V3 swap amounts are signed from the pool's perspective: the token with a
+      // positive amount was sold INTO the pool (the trade input), the token with a negative
+      // amount was bought OUT of the pool (the trade output). Label the activity in the user's
+      // actual trade direction instead of a fixed token0 -> token1, which rendered ~half of all
+      // swaps backwards (e.g. a TAIKO->ETH swap shown as "Swap WETH for TAIKO").
+      const amount0 = parseFloat(swap.amount0)
+      const amount1 = parseFloat(swap.amount1)
+      const token0IsInput = amount0 >= 0
+      const inputToken = token0IsInput ? token0 : token1
+      const outputToken = token0IsInput ? token1 : token0
+      const inputInfo = token0IsInput ? swap.pool.token0 : swap.pool.token1
+      const outputInfo = token0IsInput ? swap.pool.token1 : swap.pool.token0
+      const inputAmount = Math.abs(token0IsInput ? amount0 : amount1)
+      const outputAmount = Math.abs(token0IsInput ? amount1 : amount0)
+
       allActivities.push({
         hash: swap.transaction.id,
         chainId: chainId!,
@@ -49,10 +64,10 @@ export function useTaikoActivityAdapter(account: string): {
         timestamp: parseInt(swap.timestamp),
         from: swap.origin,
         nonce: undefined,
-        title: `Swap ${swap.pool.token0.symbol} for ${swap.pool.token1.symbol}`,
-        descriptor: `${Math.abs(parseFloat(swap.amount0))} ${swap.pool.token0.symbol} → ${Math.abs(parseFloat(swap.amount1))} ${swap.pool.token1.symbol}`,
-        logos: [swap.pool.token0.id, swap.pool.token1.id],
-        currencies: [token0, token1],
+        title: `Swap ${inputInfo.symbol} for ${outputInfo.symbol}`,
+        descriptor: `${inputAmount} ${inputInfo.symbol} → ${outputAmount} ${outputInfo.symbol}`,
+        logos: [inputInfo.id, outputInfo.id],
+        currencies: [inputToken, outputToken],
       } as Activity)
     })
 

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -478,7 +478,6 @@ export function Swap({
   )
 
   const handleContinueToReview = useCallback(() => {
-    console.log('🔍 handleContinueToReview called', { trade, allowance })
     setSwapState({
       tradeToConfirm: trade,
       swapError: undefined,
@@ -830,12 +829,20 @@ export function Swap({
                 }}
                 id="swap-button"
                 data-testid="swap-button"
-                disabled={!getIsValidSwapQuote(trade, tradeState, swapInputError)}
+                // Disable while the (token) allowance is still loading. The ConfirmSwapModal is gated
+                // on `allowance.state !== LOADING`, so without this the button looks active but clicking
+                // it is a silent no-op ("the pink button isn't working") until the allowance read lands.
+                disabled={
+                  !getIsValidSwapQuote(trade, tradeState, swapInputError) ||
+                  allowance.state === AllowanceState.LOADING
+                }
                 error={!swapInputError && priceImpactSeverity > 2 && allowance.state === AllowanceState.ALLOWED}
               >
                 <Text fontSize={20}>
                   {swapInputError ? (
                     swapInputError
+                  ) : allowance.state === AllowanceState.LOADING ? (
+                    <Trans>Loading…</Trans>
                   ) : routeIsSyncing || routeIsLoading ? (
                     <Trans>Swap</Trans>
                   ) : priceImpactSeverity > 2 ? (

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -4,6 +4,7 @@ import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
 import { DutchOrderInfo, DutchOrderInfoJSON } from '@uniswap/uniswapx-sdk'
 import { Pair, Route as V2Route } from '@uniswap/v2-sdk'
 import { FeeAmount, Pool, Route as V3Route } from '@uniswap/v3-sdk'
+import { isTaikoChain } from 'config/chains'
 import { isAvalanche, isBsc, isMatic, nativeOnChain } from 'constants/tokens'
 import { toSlippagePercent } from 'utils/slippage'
 
@@ -318,6 +319,11 @@ export function isUniswapXTrade(trade?: InterfaceTrade): trade is DutchOrderTrad
 }
 
 export function shouldUseAPIRouter(args: GetQuoteArgs): boolean {
+  // Taiko is not served by Uniswap's hosted routing API and requests to it are CORS-blocked from
+  // swap.taiko.xyz. The quote always falls back to client-side routing anyway, so skip the hosted
+  // attempt entirely to avoid a wasted failed request and the alarming CORS / "GetQuote failed on
+  // Unified Routing API" console errors on every quote.
+  if (isTaikoChain(args.tokenInChainId)) return false
   return args.routerPreference !== RouterPreference.CLIENT
 }
 

--- a/src/utils/getTaikoTokenMap.test.ts
+++ b/src/utils/getTaikoTokenMap.test.ts
@@ -1,0 +1,35 @@
+import { getAddress } from '@ethersproject/address'
+
+import { getTaikoTokenMap, mergeTaikoTokens } from './getTaikoTokenMap'
+
+const TAIKO_MAINNET_CHAIN_ID = 167000
+// Checksummed TAIKO token address (as produced by currencyId() / ethers Contract.address).
+const TAIKO_ADDRESS = '0xA9d23408b9bA935c230493c40C73824Df71A0975'
+
+describe('getTaikoTokenMap', () => {
+  it('keys tokens by their checksummed address so lookups by currencyId resolve (not "Unknown")', () => {
+    const map = getTaikoTokenMap()
+    const mainnet = map[TAIKO_MAINNET_CHAIN_ID]!
+
+    // The activity/popup code looks tokens up by the checksummed currencyId, e.g.
+    // tokens[chainId][approval.tokenAddress]. That key must exist.
+    expect(mainnet[TAIKO_ADDRESS]).toBeDefined()
+    expect(mainnet[TAIKO_ADDRESS]?.symbol).toBe('TAIKO')
+
+    // Guard against a regression to lowercase keying, which made every lookup miss.
+    expect(mainnet[TAIKO_ADDRESS.toLowerCase()]).toBeUndefined()
+  })
+
+  it('uses the checksummed address as the key for every common token', () => {
+    const mainnet = getTaikoTokenMap()[TAIKO_MAINNET_CHAIN_ID]!
+    Object.entries(mainnet).forEach(([key, token]) => {
+      expect(key).toBe(getAddress(key))
+      expect(token?.address).toBe(key)
+    })
+  })
+
+  it('merges Taiko tokens into an existing map under checksummed keys', () => {
+    const merged = mergeTaikoTokens({})
+    expect(merged[TAIKO_MAINNET_CHAIN_ID]?.[TAIKO_ADDRESS]?.symbol).toBe('TAIKO')
+  })
+})

--- a/src/utils/getTaikoTokenMap.ts
+++ b/src/utils/getTaikoTokenMap.ts
@@ -51,11 +51,15 @@ const TAIKO_HOODI_COMMON_TOKENS = [
 export function getTaikoTokenMap(): ChainTokenMap {
   const taikoMap: ChainTokenMap = {}
 
-  // Add Taiko Mainnet tokens
+  // Add Taiko Mainnet tokens.
+  // NOTE: key by the checksummed `token.address`, NOT a lowercased address. Consumers look these
+  // tokens up by `currencyId` (e.g. parseLocal.getCurrency, PopupContent), which is the checksummed
+  // address. Lowercasing the key here made every lookup miss, rendering tokens as "Unknown"
+  // (e.g. "Approving Unknown", "Swapping Unknown for ETH"). Matches useAllTokensMultichain keying.
   const taikoMainnetTokens: { [address: string]: Token } = {}
   TAIKO_MAINNET_COMMON_TOKENS.forEach((tokenInfo) => {
     const token = new Token(167000, tokenInfo.address, tokenInfo.decimals, tokenInfo.symbol, tokenInfo.name)
-    taikoMainnetTokens[tokenInfo.address.toLowerCase()] = token
+    taikoMainnetTokens[token.address] = token
   })
   taikoMap[167000] = taikoMainnetTokens
 
@@ -63,7 +67,7 @@ export function getTaikoTokenMap(): ChainTokenMap {
   const taikoHoodiTokens: { [address: string]: Token } = {}
   TAIKO_HOODI_COMMON_TOKENS.forEach((tokenInfo) => {
     const token = new Token(167013, tokenInfo.address, tokenInfo.decimals, tokenInfo.symbol, tokenInfo.name)
-    taikoHoodiTokens[tokenInfo.address.toLowerCase()] = token
+    taikoHoodiTokens[token.address] = token
   })
   taikoMap[167013] = taikoHoodiTokens
 


### PR DESCRIPTION
Production hadn't been redeployed in 44 days, so nothing in our code "changed" — the trigger was external (Taiko RPC latency + the subgraph reindex), which surfaced several latent bugs in the Taiko swap flow. This fixes the user-facing ones reported in #swap-bugs.

| # | Issue | Root cause | Fix |
|---|-------|-----------|-----|
| 1 | **TAIKO→ETH "pink button does nothing"** | The button is enabled on a valid quote and calls `handleContinueToReview()`, but `ConfirmSwapModal` is gated on `allowance.state !== LOADING`. While the token `allowance(owner, router)` read is in flight, clicking is a silent no-op. (ETH→TAIKO worked because native input needs no allowance.) | Button now shows **"Loading…"** and is disabled while the allowance read is in flight, so it's consistent with the modal gate and gives feedback. Also removed a leftover `console.log` firing on every click. |
| 2 | **Activity feed shows the wrong direction** | The adapter always labeled swaps `token0 → token1` with `Math.abs` amounts, ignoring the signed V3 amount convention → ~half of all swaps rendered backwards (e.g. a TAIKO→ETH swap shown as "Swap WETH for TAIKO"). | Derive input/output from the amount sign (positive = sold into pool, negative = bought out). |
| 3 | **"Approving Unknown" / "Swapping Unknown for ETH"** | `DEFAULT_LIST_OF_LISTS` is empty for Taiko, so `mergeTaikoTokens` is the only token source for local/pending activity — but it keyed tokens by **lowercase** address while `getCurrency`/popups look up by the **checksummed** `currencyId`, so every lookup missed. | Key the Taiko token map by the checksummed `token.address` (matches `useAllTokensMultichain`). |
| 4 | **Scary CORS / "GetQuote failed on Unified Routing API" console errors** | Red herring — Taiko isn't served by the hosted `api.uniswap.org` router and the request is CORS-blocked, but the quote always falls back to client-side routing and succeeds. | `shouldUseAPIRouter` returns `false` for Taiko, skipping the doomed request entirely. |

Verified: `tsc` clean for the edited files (the project's other tsc errors are pre-existing — codegen is skipped, it builds via SWC); the direction logic checked against live subgraph samples; the token-map keying verified (lowercase → "Unknown", checksummed → "TAIKO"). Unit tests added for #2 and #3.

Note: the jest suite needs Node 20 (repo's `.nvmrc`); it can't run on Node 24 because the `@swc` native binary fails there.

Follow-up (not in this PR — it's infra, not a code bug): the "stuck on Approving" and "re-asks for approval even though approved" reports are on-chain read latency on the public RPC `rpc.mainnet.taiko.xyz` (12s polling + per-block `eth_call` caching). Worth considering a faster/dedicated RPC for swap.taiko.xyz.
