### PR TITLE
fix: surface Taiko chain stalls in minutes instead of 25

### DIFF
--- a/src/constants/chainInfo.ts
+++ b/src/constants/chainInfo.ts
@@ -263,7 +263,10 @@ const CHAIN_INFO: ChainInfoMap = {
   },
   [TAIKO_MAINNET_CHAIN_ID]: {
     networkType: NetworkType.L2,
-    blockWaitMsBeforeWarning: ms(`25m`),
+    // Taiko produces a block every ~2s, so a 3m-old head is ~90 missed blocks — an unambiguous
+    // stall. (The timestamp feeding this check refreshes every ~12s, so the threshold only needs
+    // to comfortably exceed that; the 25m value tuned for other L2s hid outages for 25 minutes.)
+    blockWaitMsBeforeWarning: ms(`3m`),
     bridge: 'https://bridge.taiko.xyz',
     docs: 'https://docs.taiko.xyz/',
     explorer: 'https://taikoscan.io/',
@@ -279,7 +282,9 @@ const CHAIN_INFO: ChainInfoMap = {
   },
   [TAIKO_HOODI_CHAIN_ID]: {
     networkType: NetworkType.L2,
-    blockWaitMsBeforeWarning: ms(`25m`),
+    // Hoodi also targets ~2s blocks, but testnets idle and hiccup more; 10m avoids crying wolf
+    // while still surfacing real stalls an order of magnitude sooner than the old 25m.
+    blockWaitMsBeforeWarning: ms(`10m`),
     bridge: 'https://bridge.taiko.xyz',
     docs: 'https://docs.taiko.xyz/',
     explorer: 'https://hoodi.taikoscan.io/',

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -115,7 +115,6 @@ export const L2_CHAIN_IDS = [
   ChainId.BASE,
   TAIKO_MAINNET_CHAIN_ID,
   TAIKO_HOODI_CHAIN_ID,
-  TAIKO_MAINNET_CHAIN_ID,
 ] as const
 
 export type SupportedL2ChainId = (typeof L2_CHAIN_IDS)[number]


### PR DESCRIPTION
# Description

Fixes the chain-connectivity warning taking 25 minutes to appear on a chain that produces a block every ~2 seconds.

`blockWaitMsBeforeWarning` for both Taiko chains was `ms('25m')`, copied from the Optimism/Base entries in `chainInfo.ts`. On Taiko that means ~750 consecutive missed blocks — users watch silently stale prices for 25 minutes before `ChainConnectivityWarning` shows. Now:

- **Taiko mainnet: 3m** (~90 missed blocks — an unambiguous stall, and comfortably above the ~12s refresh cadence of the multicall-fetched timestamp that feeds the check, so no false positives from normal operation)
- **Taiko Hoodi: 10m** (testnets idle and hiccup more; still 2.5× faster than before)

Also removes a duplicate `TAIKO_MAINNET_CHAIN_ID` entry from `L2_CHAIN_IDS`, which leaked into WalletConnect's `optionalChains`.

**Part of the block-time support stack** (full review & plan in #50). Originally stacked on #44's branch while `main` CI was red; after #51 (which carried #44's multicall fix plus the CI repair) merged, this branch was **rebased onto `main` and retargeted** — the rebased tree is byte-identical to the one verified before. Independent of #47/#49; mergeable any time.

_Relevant docs:_ #50 (review & implementation plan)

## Screen capture

No new UI: the existing yellow polling dot + "Network Warning" card simply trigger after 3 minutes of no new blocks instead of 25.

## Test plan

### QA (ie manual testing)
- [ ] Simulate a stall (block a Taiko RPC in devtools with the app loaded) and confirm the warning appears after ~3m on mainnet config.

### Automated testing
- [x] Full jest suite on this branch: 115 suites / 651 tests passing, 59/59 snapshots (values are config-only; `chains`/`chainInfo`/`Polling` suites pass).
- [x] `tsc` clean, `yarn lint` 0 errors on changed files.
- [x] Integration/E2E test N/A (threshold constant change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMukeaL5GHybRQqfJcS6Zo