### PR TITLE
fix: cap local caching of the web app at 24 hours

### DIFF
--- a/src/serviceWorker/index.ts
+++ b/src/serviceWorker/index.ts
@@ -27,7 +27,7 @@ registerRoute(
     ({ url }) => onDemandURLs.includes('.' + url.pathname),
     new CacheFirst({
       cacheName: onDemandCacheName,
-      plugins: [new ExpirationPlugin({ maxEntries: 64 })],
+      plugins: [new ExpirationPlugin({ maxEntries: 64, maxAgeSeconds: 24 * 60 * 60 })],
     })
   )
 )

--- a/vercel.json
+++ b/vercel.json
@@ -12,5 +12,34 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "/(fonts|images|nft)/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "/((?!static/|fonts/|images/|nft/).*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Description

Guarantees that no locally cached copy of the web app outlives 24 hours, so users can't get stuck on a stale build (e.g. the spurious "Network Warning / Taiko might be down" state investigated on swap.taiko.xyz).

Two layers cache the app locally, and both previously had no explicit ceiling:

- **HTTP cache (Vercel):** swap.taiko.xyz relied on Vercel's implicit default headers. Pins explicit `Cache-Control` headers in `vercel.json`:
  - `/static/*` (content-hashed build assets) and `/fonts|images|nft/*`: `public, max-age=86400` (24h ceiling; also a small perf win over the previous `max-age=0`, since hashed assets no longer need a revalidation round-trip on every load).
  - Everything else — `index.html` (all SPA routes via the rewrite), `service-worker.js`, `manifest.json`, etc.: `no-cache`, i.e. revalidate via ETag on every load, so new deploys are picked up immediately.
- **Service worker (CacheStorage):** the on-demand `CacheFirst` cache in `src/serviceWorker/index.ts` expired entries only by LRU count (`maxEntries: 64`) — a cached chunk could live indefinitely. Adds `maxAgeSeconds: 24 * 60 * 60` so no CacheStorage entry is served past 24h.

No behavior change for the document itself: the service worker's document caching route is gated to uniswap.org domains and never runs on swap.taiko.xyz, and `index.html` already revalidated on every load — that behavior is now explicit and pinned instead of inherited from host defaults.

_Relevant docs:_ [Vercel headers config](https://vercel.com/docs/project-configuration#headers), [workbox-expiration ExpirationPlugin](https://developer.chrome.com/docs/workbox/modules/workbox-expiration/)

## Test plan

### QA (ie manual testing)

- [ ] After deploy, `curl -sI https://swap.taiko.xyz/static/js/main.<hash>.js | grep -i cache-control` returns `public, max-age=86400`
- [ ] `curl -sI https://swap.taiko.xyz/` and `.../service-worker.js` return `cache-control: no-cache`
- [ ] In DevTools → Application → Cache Storage, on-demand entries older than 24h are refetched rather than served

### Automated testing

- [x] Unit test — no new logic to test (config values only); existing suites pass: `tsc` clean, `src/serviceWorker` tests 24/24 green
- [x] Integration/E2E test N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzTAWaPTZhjBDcxiBiE1cQ)_