### PR TITLE
fix: let slow multicalls settle before refreshing

### DIFF
--- a/docs/superpowers/plans/2026-07-26-multicall-settlement-gate.md
+++ b/docs/superpowers/plans/2026-07-26-multicall-settlement-gate.md
@@ -1,0 +1,265 @@
+# Multicall Settlement Gate Implementation Plan
+
+> **For Codex:** Implement each task test-first and keep the change confined to
+> the shared multicall updater and its tests.
+
+**Goal:** Allow slow multicall requests to settle without being cancelled by
+new Taiko blocks, then refresh their stale results at the newest queued block.
+
+**Architecture:** Preserve `useQuantizedBlockNumber` as the desired-block
+source. Add a small chain-keyed hook that forwards desired blocks only when
+Redux reports no multicall request in flight for that updater's chain. Apply it
+independently to the active and dedicated-mainnet updater feeds, and remount
+the dependency's active updater when the connected chain changes so its
+instance-local cancellation callbacks cannot cross chains.
+
+**Tech stack:** React hooks, Redux Toolkit state from
+`@uniswap/redux-multicall`, TypeScript, Jest, React Testing Library.
+
+---
+
+## Task 1: Specify and implement the settlement state machine
+
+**Files:**
+
+- Modify: `src/lib/state/multicall.test.tsx`
+- Modify: `src/lib/state/multicall.tsx`
+
+### Step 1: Add failing hook tests
+
+Import a new exported `useSettledBlockNumber` hook and add a
+`renderSettled(...)` test helper parallel to `renderQuantized(...)`.
+
+Cover these transitions:
+
+```ts
+it('adopts desired blocks while idle', () => {
+  // undefined -> 100 -> 106 while isFetching is false
+  // Expect each defined desired block to be forwarded.
+})
+
+it('holds while fetching and coalesces to the newest desired block', () => {
+  // Start settled at 100.
+  // Rerender at 106/fetching and 112/fetching: expect 100.
+  // Rerender at 112/not fetching: expect 112, never 106.
+})
+
+it('does not carry a block across a chain switch', () => {
+  // Set chain A to 100.
+  // Switch to chain B with no block: expect undefined.
+  // Supply chain B block 102: expect 102.
+})
+
+it('queues a lower reorg block until the current fetch settles', () => {
+  // Settle at 100, request 90 while fetching: expect 100.
+  // Clear fetching: expect 90.
+})
+```
+
+### Step 2: Run the focused tests and confirm the missing-hook failure
+
+Run:
+
+```bash
+yarn test src/lib/state/multicall.test.tsx --runInBand
+```
+
+Expected: the suite fails because `useSettledBlockNumber` is not exported.
+
+### Step 3: Implement the minimal hook
+
+In `src/lib/state/multicall.tsx`, add:
+
+```ts
+export function useSettledBlockNumber(
+  chainId: number | undefined,
+  desiredBlockNumber: number | undefined,
+  isFetching: boolean
+): number | undefined
+```
+
+Store `{ chainId, block }` in React state. In an effect, adopt
+`desiredBlockNumber` only when `isFetching` is false. Return a block only when
+the stored `chainId` matches the current one; otherwise return `undefined`.
+
+This deliberately does not add timers, queues, or retry logic. The latest
+desired input is already the coalesced queue, and the dependency owns retries.
+
+### Step 4: Rerun the focused tests
+
+Run the same Jest command.
+
+Expected: all hook and existing quantization tests pass.
+
+---
+
+## Task 2: Gate both real multicall updater feeds
+
+**Files:**
+
+- Modify: `src/lib/state/multicall.test.tsx`
+- Modify: `src/lib/state/multicall.tsx`
+
+### Step 1: Add failing updater integration tests
+
+Use the real application store and real multicall reducer actions while keeping
+the existing spy around the inner `multicall.Updater`.
+
+The first test should:
+
+1. Render `MulticallUpdater` on Taiko mainnet at `BLOCK`.
+2. Dispatch `multicall.actions.fetchingMulticallResults` for a synthetic call
+   on `TAIKO_MAINNET_CHAIN_ID` at `BLOCK`.
+3. Emit `BLOCK + STEP` from the fake provider.
+4. Assert that the active updater still receives `BLOCK`.
+5. Dispatch `multicall.actions.updateMulticallResults` for the synthetic call
+   at `BLOCK`.
+6. Assert that the active updater now receives `BLOCK + STEP`.
+
+The second test should prove updater-key isolation while the Taiko-mainnet
+provider advances both desired feeds:
+
+1. Mark `TAIKO_MAINNET_CHAIN_ID` fetching and emit `BLOCK + STEP`.
+2. Assert that only the active updater is held; the updater registered under
+   `ChainId.MAINNET` advances.
+3. Settle the active marker.
+4. Mark `ChainId.MAINNET` fetching and emit `BLOCK + 2 * STEP`.
+5. Assert that only the dedicated-mainnet updater is held; the active updater
+   advances.
+6. Settle the mainnet marker.
+
+Add `afterEach` cleanup using `errorFetchingMulticallResults` for the synthetic
+calls on both Redux chain keys so a failed assertion cannot leave the shared
+test store in a fetching state.
+
+This test represents a request that crosses a full refresh window and proves
+the result action, rather than elapsed blocks, releases the gate.
+
+### Step 2: Run the focused suite and confirm the block advances too early
+
+Run:
+
+```bash
+yarn test src/lib/state/multicall.test.tsx --runInBand
+```
+
+Expected: the new integration test reports `BLOCK + STEP` while the synthetic
+request is still marked fetching.
+
+### Step 3: Derive per-chain fetching state and apply the hook
+
+Import `useAppSelector` and add a small internal selector hook:
+
+```ts
+function useMulticallFetching(chainId: number | undefined): boolean {
+  return useAppSelector((state) => {
+    if (chainId === undefined) return false
+    return Object.values(state.multicall.callResults[chainId] ?? {}).some(
+      (result) => typeof result.fetchingBlockNumber === 'number'
+    )
+  })
+}
+```
+
+In `MulticallUpdater`, call `useSettledBlockNumber` independently for:
+
+- `chainId` plus `latestBlockNumber`; and
+- `ChainId.MAINNET` plus `latestMainnetBlockNumber`.
+
+Pass the settled values to the corresponding inner updaters. Do not change
+contracts, listener options, quantization, receipt snapping, or pool hooks.
+
+### Step 4: Rerun the focused suite
+
+Run:
+
+```bash
+yarn test src/lib/state/multicall.test.tsx --runInBand
+```
+
+Expected: the new slow-fetch regression and all existing feed tests pass.
+
+---
+
+## Task 3: Isolate dependency cancellation state across chain switches
+
+**Files:**
+
+- Modify: `src/lib/state/multicall.test.tsx`
+- Modify: `src/lib/state/multicall.tsx`
+
+### Step 1: Add a failing chain-switch lifecycle test
+
+For this test, make the mocked inner updater record mount and unmount chain
+IDs with a `useEffect`.
+
+The test should:
+
+1. Render chain A and mark a synthetic chain-A call fetching.
+2. Switch the mocked wallet and rerender on chain B.
+3. Assert that the chain-A inner updater unmounted.
+4. Switch back to chain A before its request settles and assert its forwarded
+   block is `undefined`, not a block retained from chain B.
+5. Dispatch a real result action for the old chain-A request.
+6. Assert that chain A adopts its current desired block.
+
+Without a React key, the same dependency updater instance is reused at step 2,
+so the unmount assertion fails.
+
+### Step 2: Key the active inner updater by chain
+
+Add `key={chainId}` to only the active-wallet `multicall.Updater`. The
+dedicated-mainnet updater has a constant Redux chain and does not need a
+dynamic key.
+
+### Step 3: Rerun the focused suite
+
+```bash
+yarn test src/lib/state/multicall.test.tsx --runInBand
+```
+
+Expected: all settlement, isolation, switch, quantization, and receipt tests
+pass.
+
+---
+
+## Task 4: Verify the surgical change
+
+**Files:**
+
+- Verify: `src/lib/state/multicall.tsx`
+- Verify: `src/lib/state/multicall.test.tsx`
+
+### Step 1: Run TypeScript
+
+```bash
+yarn typecheck --pretty false
+```
+
+Expected: no TypeScript errors.
+
+### Step 2: Lint the changed source and test
+
+```bash
+yarn eslint src/lib/state/multicall.tsx src/lib/state/multicall.test.tsx
+```
+
+Expected: no lint errors.
+
+### Step 3: Inspect the final diff
+
+```bash
+git diff --check
+git diff --stat origin/main...
+git diff origin/main... -- src/lib/state/multicall.tsx src/lib/state/multicall.test.tsx
+```
+
+Confirm every changed production line belongs to block settlement and no
+dependency, provider, pool hook, or unrelated formatting changed.
+
+### Step 4: Commit the implementation
+
+```bash
+git add src/lib/state/multicall.tsx src/lib/state/multicall.test.tsx
+git commit -m "fix: let slow multicalls settle before refreshing"
+```

--- a/docs/superpowers/specs/2026-07-26-multicall-settlement-gate-design.md
+++ b/docs/superpowers/specs/2026-07-26-multicall-settlement-gate-design.md
@@ -1,0 +1,136 @@
+# Multicall Settlement Gate Design
+
+## Context
+
+Taiko produces blocks roughly every two seconds. `@uniswap/redux-multicall`
+cancels an in-flight fetch whenever the `latestBlockNumber` prop advances.
+Wallet extensions, WalletConnect sessions, and rate-limited RPC endpoints can
+take longer than the block interval, so repeated block updates can cancel every
+request before its result reaches Redux. `/pools` exposes this as an indefinite
+loading skeleton because its position discovery consists of several dependent
+multicall stages.
+
+The existing mitigation quantizes the block feed to the interface's 12-second
+data refresh window. It fixes providers faster than that window, but a slower
+request can still be cancelled at every boundary and therefore never settle.
+
+## Goals
+
+- Let an in-flight multicall finish regardless of normal block progression.
+- Make its result available immediately, even when it is behind the newest
+  observed block.
+- Refresh stale results at the newest queued block after the prior request
+  settles.
+- Preserve receipt-driven fast refreshes, reorg handling, chain isolation, and
+  the current steady-state refresh cadence.
+- Fix the shared multicall path rather than adding `/pools`-specific loading
+  code.
+
+## Non-goals
+
+- Replacing `@uniswap/redux-multicall`.
+- Changing RPC provider selection or wallet connection behavior.
+- Adding caching, pagination, or new `/pools` UI states.
+- Masking a provider that never returns or exhausts the dependency's retry
+  policy.
+
+## Considered Approaches
+
+### Patch `@uniswap/redux-multicall`
+
+Changing the package's cancellation semantics would address the problem at its
+source, but this repository would need to maintain a patch against compiled
+dependency output. Upgrades would be fragile and test coverage would depend on
+private package behavior.
+
+### Add a shared settlement gate
+
+Keep the dependency unchanged and prevent its `latestBlockNumber` prop from
+changing while Redux reports an in-flight fetch for that updater's chain. This
+is small, testable in application code, and covers all shared multicall
+consumers.
+
+### Build a `/pools`-specific loader
+
+A dedicated loader or forced public-provider path would be narrow, but it would
+duplicate multicall behavior and leave the same failure mode elsewhere.
+
+## Chosen Design
+
+Add a settlement hook in `src/lib/state/multicall.tsx`. It receives:
+
+- the Redux chain key used by one `multicall.Updater`;
+- the newest block selected by the existing quantizer; and
+- whether that chain currently has any multicall result with a numeric
+  `fetchingBlockNumber`.
+
+The hook stores the last block forwarded to the dependency:
+
+1. When no request is in flight, adopt the newest desired block.
+2. While any request is in flight, retain the forwarded block. New quantized
+   blocks and receipt snaps are implicitly coalesced in the desired input.
+3. When all requests settle, adopt the newest desired block. Redux keeps the
+   prior result available with `syncing: true`, and the dependency begins a
+   background refresh for the new block.
+4. Key stored state by chain. During a switch, return `undefined` until the new
+   chain's value is adopted so a block from the previous chain cannot leak.
+
+Apply the hook independently to:
+
+- the active-wallet updater keyed by the connected `chainId`; and
+- the dedicated Taiko-mainnet feed registered under `ChainId.MAINNET`.
+
+The gate is downstream of quantization:
+
+```text
+raw blocks / confirmed receipts
+              |
+              v
+       12-second quantizer
+              |
+              v
+         desired block
+              |
+              v
+ settlement gate per Redux chain
+              |
+              v
+   @uniswap/redux-multicall
+```
+
+## Failure Handling
+
+- Retryable RPC failures remain inside the dependency's existing retry policy.
+  Because normal block changes no longer cancel the request, a later successful
+  retry can settle and release the gate.
+- A terminal fetch error clears `fetchingBlockNumber`; the gate then advances
+  and allows the dependency to retry at the newest desired block.
+- Receipt snaps received during a fetch are queued rather than cancelling the
+  fetch. They are forwarded as soon as it settles.
+- A chain switch observes fetching state only for the new Redux chain key and
+  never forwards the old chain's block.
+
+## Tests
+
+Extend `src/lib/state/multicall.test.tsx` with:
+
+- hook tests proving initial adoption, coalescing several newer blocks while
+  fetching, release to only the newest block, and chain-switch isolation;
+- updater integration coverage that dispatches the dependency's real
+  `fetchingMulticallResults` action, advances the fake provider beyond a
+  quantization window, and verifies the inner updater's block remains fixed;
+- settlement coverage that dispatches a real result action and verifies the
+  newest queued block is then forwarded;
+- existing quantization, receipt-snap, Hoodi, and mainnet-feed tests as
+  regressions.
+
+Run the targeted Jest file, TypeScript checking, and lint on the changed source
+and test files.
+
+## Success Criteria
+
+- With blocks arriving every two seconds, a simulated fetch lasting longer
+  than multiple refresh windows is never superseded by a newer block prop.
+- The first settled result remains usable while the updater refreshes it.
+- The fast path and the 12-second steady-state cadence are unchanged.
+- Active-chain and dedicated-mainnet updater state remain independent.

--- a/docs/superpowers/specs/2026-07-26-multicall-settlement-gate-design.md
+++ b/docs/superpowers/specs/2026-07-26-multicall-settlement-gate-design.md
@@ -74,6 +74,10 @@ The hook stores the last block forwarded to the dependency:
    background refresh for the new block.
 4. Key stored state by chain. During a switch, return `undefined` until the new
    chain's value is adopted so a block from the previous chain cannot leak.
+5. Key the active inner `multicall.Updater` React element by `chainId`.
+   `@uniswap/redux-multicall` stores cancellation callbacks inside an updater
+   instance; remounting on a switch prevents the new chain from cancelling the
+   old chain's in-flight request and orphaning its Redux fetching marker.
 
 Apply the hook independently to:
 
@@ -107,8 +111,9 @@ raw blocks / confirmed receipts
   and allows the dependency to retry at the newest desired block.
 - Receipt snaps received during a fetch are queued rather than cancelling the
   fetch. They are forwarded as soon as it settles.
-- A chain switch observes fetching state only for the new Redux chain key and
-  never forwards the old chain's block.
+- A chain switch remounts the active dependency updater. The old request can
+  still settle its old-chain Redux marker, while the new chain observes only
+  its own fetching state and never receives the old chain's block.
 
 ## Tests
 
@@ -121,6 +126,10 @@ Extend `src/lib/state/multicall.test.tsx` with:
   quantization window, and verifies the inner updater's block remains fixed;
 - settlement coverage that dispatches a real result action and verifies the
   newest queued block is then forwarded;
+- isolation coverage proving fetching state for the active and
+  dedicated-mainnet Redux keys freezes only its matching updater;
+- chain-switch coverage proving the active updater remounts, the old chain's
+  block does not leak, and an eventual old-chain result releases its gate;
 - existing quantization, receipt-snap, Hoodi, and mainnet-feed tests as
   regressions.
 

--- a/src/lib/state/multicall.test.tsx
+++ b/src/lib/state/multicall.test.tsx
@@ -1,12 +1,15 @@
 import { renderHook } from '@testing-library/react'
+import { ChainId } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
 import { EventEmitter } from 'events'
 import { useFastForwardBlockNumber } from 'lib/hooks/useBlockNumber'
+import { useEffect, useState } from 'react'
+import store from 'state'
 import { mocked } from 'test-utils/mocked'
 import { act, render } from 'test-utils/render'
 
-import multicall, { MulticallUpdater, useQuantizedBlockNumber } from './multicall'
+import multicall, { MulticallUpdater, useQuantizedBlockNumber, useSettledBlockNumber } from './multicall'
 
 jest.mock('hooks/useContract', () => {
   const useContract = jest.requireActual('hooks/useContract')
@@ -35,6 +38,14 @@ function renderQuantized(initial: { chainId?: number; blockNumber?: number; step
       step?: number
       snapTo?: number
     }) => useQuantizedBlockNumber(chainId ?? CHAIN_A, blockNumber, step ?? STEP, snapTo),
+    { initialProps: initial }
+  )
+}
+
+function renderSettled(initial: { chainId?: number; blockNumber?: number; isFetching?: boolean }) {
+  return renderHook(
+    ({ chainId, blockNumber, isFetching }: { chainId?: number; blockNumber?: number; isFetching?: boolean }) =>
+      useSettledBlockNumber(chainId ?? CHAIN_A, blockNumber, isFetching ?? false),
     { initialProps: initial }
   )
 }
@@ -125,6 +136,44 @@ describe('useQuantizedBlockNumber', () => {
   })
 })
 
+describe('useSettledBlockNumber', () => {
+  it('adopts desired blocks while idle', () => {
+    const { result, rerender } = renderSettled({ blockNumber: undefined })
+    expect(result.current).toBeUndefined()
+    rerender({ blockNumber: 100 })
+    expect(result.current).toEqual(100)
+    rerender({ blockNumber: 106 })
+    expect(result.current).toEqual(106)
+  })
+
+  it('holds while fetching and coalesces to the newest desired block', () => {
+    const { result, rerender } = renderSettled({ blockNumber: 100 })
+    rerender({ blockNumber: 106, isFetching: true })
+    expect(result.current).toEqual(100)
+    rerender({ blockNumber: 112, isFetching: true })
+    expect(result.current).toEqual(100)
+    rerender({ blockNumber: 112, isFetching: false })
+    expect(result.current).toEqual(112)
+  })
+
+  it('does not carry a block across a chain switch', () => {
+    const { result, rerender } = renderSettled({ chainId: CHAIN_A, blockNumber: 100 })
+    expect(result.current).toEqual(100)
+    rerender({ chainId: CHAIN_B, blockNumber: undefined })
+    expect(result.current).toBeUndefined()
+    rerender({ chainId: CHAIN_B, blockNumber: 102 })
+    expect(result.current).toEqual(102)
+  })
+
+  it('queues a lower reorg block until the current fetch settles', () => {
+    const { result, rerender } = renderSettled({ blockNumber: 100 })
+    rerender({ blockNumber: 90, isFetching: true })
+    expect(result.current).toEqual(100)
+    rerender({ blockNumber: 90, isFetching: false })
+    expect(result.current).toEqual(90)
+  })
+})
+
 describe('MulticallUpdater', () => {
   // Mimics an ethers provider: emits 'block' events and answers getBlockNumber().
   class FakeProvider extends EventEmitter {
@@ -139,6 +188,22 @@ describe('MulticallUpdater', () => {
   // Far above any real Taiko block number, so the ambient mainnet-block fetch
   // (swallowed in tests) can never outrank the fake feed.
   const BLOCK = 1_000_000_100
+  const ACTIVE_CALL = {
+    address: '0x0000000000000000000000000000000000000002',
+    callData: '0x1234',
+  }
+  const MAINNET_CALL = {
+    address: '0x0000000000000000000000000000000000000003',
+    callData: '0x5678',
+  }
+  const ISOLATION_ACTIVE_CALL = {
+    address: '0x0000000000000000000000000000000000000004',
+    callData: '0x9abc',
+  }
+  const SWITCH_CALL = {
+    address: '0x0000000000000000000000000000000000000005',
+    callData: '0xdef0',
+  }
 
   let fastForward: (block: number) => void
   function Probe() {
@@ -151,8 +216,46 @@ describe('MulticallUpdater', () => {
     updaterSpy = jest.spyOn(multicall, 'Updater').mockImplementation(() => <></>)
   })
   afterEach(() => {
+    act(() => {
+      store.dispatch(
+        multicall.actions.errorFetchingMulticallResults({
+          chainId: TAIKO_MAINNET_CHAIN_ID,
+          calls: [ACTIVE_CALL, ISOLATION_ACTIVE_CALL, SWITCH_CALL],
+          fetchingBlockNumber: Number.MAX_SAFE_INTEGER,
+        })
+      )
+      store.dispatch(
+        multicall.actions.errorFetchingMulticallResults({
+          chainId: ChainId.MAINNET,
+          calls: [MAINNET_CALL],
+          fetchingBlockNumber: Number.MAX_SAFE_INTEGER,
+        })
+      )
+    })
     updaterSpy.mockRestore()
   })
+
+  function markFetching(chainId: number, call: typeof ACTIVE_CALL, blockNumber: number) {
+    store.dispatch(
+      multicall.actions.fetchingMulticallResults({
+        chainId,
+        calls: [call],
+        fetchingBlockNumber: blockNumber,
+      })
+    )
+  }
+
+  function settle(chainId: number, call: typeof ACTIVE_CALL, blockNumber: number) {
+    store.dispatch(
+      multicall.actions.updateMulticallResults({
+        chainId,
+        blockNumber,
+        results: {
+          [`${call.address}-${call.callData}`]: '0x01',
+        },
+      })
+    )
+  }
 
   /** The latest props passed to the inner multicall.Updater registered for chainId. */
   function latestUpdaterProps(chainId: number) {
@@ -162,7 +265,11 @@ describe('MulticallUpdater', () => {
 
   function renderUpdater(chainId: number, provider: FakeProvider) {
     mocked(useWeb3React).mockReturnValue({ chainId, provider } as unknown as ReturnType<typeof useWeb3React>)
-    return render(
+    return render(updaterTree())
+  }
+
+  function updaterTree() {
+    return (
       <>
         <MulticallUpdater />
         <Probe />
@@ -225,5 +332,96 @@ describe('MulticallUpdater', () => {
     })
     // Hoodi receipts snap the active feed, but are not forwarded to the mainnet feed.
     expect(latestUpdaterProps(TAIKO_HOODI_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 2)
+  })
+
+  it('holds an active updater block until its current request settles', async () => {
+    const provider = new FakeProvider(BLOCK)
+    renderUpdater(TAIKO_MAINNET_CHAIN_ID, provider)
+    await act(async () => undefined)
+
+    act(() => {
+      markFetching(TAIKO_MAINNET_CHAIN_ID, ISOLATION_ACTIVE_CALL, BLOCK)
+      provider.emit('block', BLOCK + STEP)
+      provider.emit('block', BLOCK + 2 * STEP)
+      provider.emit('block', BLOCK + 3 * STEP)
+    })
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK)
+
+    act(() => {
+      settle(TAIKO_MAINNET_CHAIN_ID, ISOLATION_ACTIVE_CALL, BLOCK)
+    })
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 3 * STEP)
+  })
+
+  it('gates the active and dedicated mainnet updater independently', async () => {
+    const provider = new FakeProvider(BLOCK)
+    renderUpdater(TAIKO_MAINNET_CHAIN_ID, provider)
+    await act(async () => undefined)
+
+    act(() => {
+      markFetching(TAIKO_MAINNET_CHAIN_ID, ACTIVE_CALL, BLOCK)
+      provider.emit('block', BLOCK + STEP)
+    })
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK)
+    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + STEP)
+
+    act(() => {
+      settle(TAIKO_MAINNET_CHAIN_ID, ACTIVE_CALL, BLOCK)
+      markFetching(ChainId.MAINNET, MAINNET_CALL, BLOCK + STEP)
+      provider.emit('block', BLOCK + 2 * STEP)
+    })
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 2 * STEP)
+    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + STEP)
+
+    act(() => {
+      settle(ChainId.MAINNET, MAINNET_CALL, BLOCK + STEP)
+    })
+    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + 2 * STEP)
+  })
+
+  it('remounts the active updater across a chain switch and releases the old chain on settlement', async () => {
+    const mounted: number[] = []
+    const unmounted: number[] = []
+    updaterSpy.mockImplementation(({ chainId }) => {
+      const [mountedChainId] = useState(chainId)
+      useEffect(() => {
+        if (mountedChainId !== undefined) mounted.push(mountedChainId)
+        return () => {
+          if (mountedChainId !== undefined) unmounted.push(mountedChainId)
+        }
+      }, [mountedChainId])
+      return <></>
+    })
+
+    const providerA = new FakeProvider(BLOCK)
+    const view = renderUpdater(CHAIN_A, providerA)
+    await act(async () => undefined)
+    act(() => {
+      markFetching(CHAIN_A, SWITCH_CALL, BLOCK)
+    })
+
+    const providerB = new FakeProvider(BLOCK + STEP)
+    mocked(useWeb3React).mockReturnValue({
+      chainId: CHAIN_B,
+      provider: providerB,
+    } as unknown as ReturnType<typeof useWeb3React>)
+    view.rerender(updaterTree())
+    await act(async () => undefined)
+
+    expect(mounted).toContain(CHAIN_B)
+    expect(unmounted).toContain(CHAIN_A)
+
+    mocked(useWeb3React).mockReturnValue({
+      chainId: CHAIN_A,
+      provider: providerA,
+    } as unknown as ReturnType<typeof useWeb3React>)
+    view.rerender(updaterTree())
+    await act(async () => undefined)
+    expect(latestUpdaterProps(CHAIN_A)?.latestBlockNumber).toBeUndefined()
+
+    act(() => {
+      settle(CHAIN_A, SWITCH_CALL, BLOCK)
+    })
+    expect(latestUpdaterProps(CHAIN_A)?.latestBlockNumber).toEqual(BLOCK)
   })
 })

--- a/src/lib/state/multicall.test.tsx
+++ b/src/lib/state/multicall.test.tsx
@@ -216,6 +216,7 @@ describe('MulticallUpdater', () => {
     updaterSpy = jest.spyOn(multicall, 'Updater').mockImplementation(() => <></>)
   })
   afterEach(() => {
+    // Unlock any synthetic fetch left in Redux by a failing assertion.
     act(() => {
       store.dispatch(
         multicall.actions.errorFetchingMulticallResults({

--- a/src/lib/state/multicall.tsx
+++ b/src/lib/state/multicall.tsx
@@ -5,6 +5,7 @@ import { blocksPerWindow, DATA_REFRESH_WINDOW_MS, TAIKO_MAINNET_CHAIN_ID } from 
 import { useInterfaceMulticall, useMainnetInterfaceMulticall } from 'hooks/useContract'
 import useBlockNumber, { useFastForwardedBlockNumber, useMainnetBlockNumber } from 'lib/hooks/useBlockNumber'
 import { useEffect, useMemo, useState } from 'react'
+import { useAppSelector } from 'state/hooks'
 
 const multicall = createMulticall()
 
@@ -14,12 +15,12 @@ export default multicall
 // number it receives changes, so if a provider's round trip is slower than the
 // block interval (common for wallet extensions and WalletConnect, especially
 // under RPC rate limits), results are discarded before they ever land and
-// pages that block on multicall data (e.g. /pools) load forever. Only
-// advancing the block number fed to the Updater once per data refresh window —
-// a block count derived from the chain's block time: 6 blocks at today's 2s
-// Taiko cadence, 24 if Taiko moves to 0.5s — gives fetches a full window to
-// complete while still refreshing at the cadence the interface was designed
-// for.
+// pages that block on multicall data (e.g. /pools) load forever. Advancing the
+// desired block once per data refresh window — a block count derived from the
+// chain's block time: 6 blocks at today's 2s Taiko cadence, 24 if Taiko moves
+// to 0.5s — preserves the interface's intended refresh cadence.
+// `useSettledBlockNumber` below then prevents even slower fetches from being
+// cancelled at a window boundary.
 //
 // `snapTo` cuts through the window: it carries the block number of a confirmed
 // receipt for one of the user's own transactions, proof that state relevant to
@@ -63,6 +64,33 @@ export function useQuantizedBlockNumber(
     )
   }, [chainId, snapTo])
   return quantized.chainId === chainId ? quantized.block : undefined
+}
+
+// Keep the block given to redux-multicall stable until its current request
+// settles. The dependency cancels in-flight work when this value changes; once
+// fetching clears, forwarding the latest desired block exposes the settled
+// result first and then starts a background refresh.
+export function useSettledBlockNumber(
+  chainId: number | undefined,
+  desiredBlockNumber: number | undefined,
+  isFetching: boolean
+): number | undefined {
+  const [settled, setSettled] = useState<{ chainId?: number; block?: number }>({})
+  useEffect(() => {
+    if (!isFetching) {
+      setSettled({ chainId, block: desiredBlockNumber })
+    }
+  }, [chainId, desiredBlockNumber, isFetching])
+  return settled.chainId === chainId ? settled.block : undefined
+}
+
+function useMulticallFetching(chainId: number | undefined): boolean {
+  return useAppSelector((state) => {
+    if (chainId === undefined) return false
+    return Object.values(state.multicall.callResults[chainId] ?? {}).some(
+      (result) => typeof result.fetchingBlockNumber === 'number'
+    )
+  })
 }
 
 /**
@@ -110,6 +138,10 @@ export function MulticallUpdater() {
     blocksPerWindow(TAIKO_MAINNET_CHAIN_ID, DATA_REFRESH_WINDOW_MS),
     chainId === TAIKO_MAINNET_CHAIN_ID ? fastForwardedBlock : undefined
   )
+  const isFetching = useMulticallFetching(chainId)
+  const isMainnetFetching = useMulticallFetching(ChainId.MAINNET)
+  const settledBlockNumber = useSettledBlockNumber(chainId, latestBlockNumber, isFetching)
+  const settledMainnetBlockNumber = useSettledBlockNumber(ChainId.MAINNET, latestMainnetBlockNumber, isMainnetFetching)
   const contract = useInterfaceMulticall()
   const mainnetContract = useMainnetInterfaceMulticall()
   const listenerOptions: ListenerOptions = useMemo(
@@ -129,14 +161,17 @@ export function MulticallUpdater() {
     <>
       <multicall.Updater
         chainId={ChainId.MAINNET}
-        latestBlockNumber={latestMainnetBlockNumber}
+        latestBlockNumber={settledMainnetBlockNumber}
         contract={mainnetContract}
         listenerOptions={mainnetListener}
       />
       {chainId !== ChainId.MAINNET && (
+        // redux-multicall stores cancellation callbacks on the updater
+        // instance, so remount it to keep callbacks from crossing chains.
         <multicall.Updater
+          key={chainId}
           chainId={chainId}
-          latestBlockNumber={latestBlockNumber}
+          latestBlockNumber={settledBlockNumber}
           contract={contract}
           listenerOptions={listenerOptions}
         />

--- a/src/lib/state/multicall.tsx
+++ b/src/lib/state/multicall.tsx
@@ -77,6 +77,8 @@ export function useSettledBlockNumber(
 ): number | undefined {
   const [settled, setSettled] = useState<{ chainId?: number; block?: number }>({})
   useEffect(() => {
+    // While fetching, the desired block keeps changing; adopt its latest value
+    // on the first render after fetching clears.
     if (!isFetching) {
       setSettled({ chainId, block: desiredBlockNumber })
     }
@@ -87,9 +89,11 @@ export function useSettledBlockNumber(
 function useMulticallFetching(chainId: number | undefined): boolean {
   return useAppSelector((state) => {
     if (chainId === undefined) return false
-    return Object.values(state.multicall.callResults[chainId] ?? {}).some(
-      (result) => typeof result.fetchingBlockNumber === 'number'
-    )
+    const callResults = state.multicall.callResults[chainId] ?? {}
+    for (const callKey in callResults) {
+      if (typeof callResults[callKey].fetchingBlockNumber === 'number') return true
+    }
+    return false
   })
 }
 


### PR DESCRIPTION
## Summary

- keep each multicall updater's block stable while that Redux chain has requests in flight
- expose an eventual slow result first, then refresh it at the newest queued block
- isolate the active-chain and dedicated-mainnet settlement gates
- remount the active updater on chain switches so dependency cancellation state cannot cross chains
- document the design and test-first implementation plan

## Root cause

`@uniswap/redux-multicall` cancels in-flight requests whenever its `latestBlockNumber` prop advances. Taiko produces blocks quickly enough that slow wallet, WalletConnect, or rate-limited RPC responses can be cancelled at every refresh boundary, leaving `/pools` in an indefinite loading state.

The existing 12-second quantization reduced cancellation frequency but still could not guarantee settlement for requests slower than that window.

## User impact

Slow responses that eventually succeed can now populate the pools page instead of being discarded. Newer blocks and confirmed-receipt refreshes are coalesced while the request runs, then fetched in the background after the settled result is available.

## Validation

- `yarn test src/lib/state/multicall.test.tsx src/lib/hooks/useBlockNumber.test.tsx --runInBand --watchAll=false` - 24 tests passed
- `yarn typecheck --pretty false`
- `yarn eslint src/lib/state/multicall.tsx src/lib/state/multicall.test.tsx`
- `git diff --check origin/main...`

Tests cover requests spanning multiple refresh windows, stale-first release, active/mainnet gate isolation, reorgs, receipt snapping, and chain-switch remount behavior.
