### PR TITLE
refactor: gate chain-data refetching in wall-clock time instead of block counts

### DIFF
--- a/TAIKO_BLOCK_TIME_SUPPORT.md
+++ b/TAIKO_BLOCK_TIME_SUPPORT.md
@@ -1,6 +1,7 @@
 # Taiko Block Time Support — Design Review & Implementation Plan
 
-**Scope.** Taiko Alethia now produces a block roughly every **2 seconds**, and the protocol roadmap
+**Scope.** Taiko Alethia now produces a block roughly every **second** (down from ~2s when this
+document was first written), and the protocol roadmap
 targets **~0.5 second** blocks (preconfirmation cadence). This interface is a fork of the Uniswap
 interface, which was designed around Ethereum L1's ~12 second cadence. This document is a full
 review of every place the interface's design or code depends on block cadence, the improvement
@@ -27,19 +28,26 @@ Everything the app "knows" about the chain flows through a small set of mechanis
                  │  (constants/providers.ts, pollingInterval = 12s)         │
                  │                                                          │
   wallet    ───► │  ethers Web3Provider over wallet EIP-1193 (poll ~4s)     │
+                 │                                                          │
+                 │  raw feed ──► wall-clock gate (useRefetchBlockNumber:    │
+                 │  advances ≤ once per 12s, snaps to confirmed receipts)   │
                  └────────────┬─────────────────────────────────────────────┘
-                              │  'block' events (bursts of ~6 on a 2s chain)
+                              │  raw 'block' events │ gated refetch feed
               ┌───────────────┼────────────────────┬──────────────────────┐
               ▼               ▼                    ▼                      ▼
       redux-multicall   tx receipt updater   Polling indicator      swap flow
-      (quantized to     (lib/hooks/          + ChainConnectivity    (gas estimate,
-      6-block steps     transactions/        Warning                analytics)
-      by PR #44)        updater.tsx)         (components/Polling)
+      + logs + position (raw feed wakes it;  + ChainConnectivity    (gas estimate,
+      fees (gated       wall-clock backoff)  Warning (raw feed)     analytics)
+      refetch feed)     (lib/hooks/transactions/updater.tsx)
 ```
 
 * **Multicall** (balances, allowances, positions, pool state, on-chain timestamp): refetches when
-  the block number fed to it advances. PR #44 quantizes that feed to 6-block steps and sets
-  `blocksPerFetch: 6` on Taiko, so the steady-state data window is **~12s**.
+  the block number fed to it advances. Originally PR #44/#49 quantized that feed in 6-block steps;
+  the "block-subscription-refetch" PR replaced the block-count step with a **wall-clock gate**
+  (`useRefetchBlockNumber`): block N is adopted at time T, and later blocks are ignored until one
+  arrives at or after T + 12s. The steady-state data window is **~12s of wall time at any block
+  cadence** (1s blocks today, 0.5s tomorrow — no config involved), and `blocksPerFetch` is 1
+  because every advance of the gated feed means "a window elapsed, refetch now".
 * **Transaction receipt updater**: when a block event arrives, checks pending transactions
   (`shouldCheck` block-count backoff), fetching receipts with per-chain retry options, then
   `fastForwardBlockNumber(receipt.blockNumber)`.
@@ -80,7 +88,7 @@ watch stale prices for 25 minutes before `ChainConnectivityWarning` appears.
 ~12–15s staleness of the multicall-fetched timestamp that feeds this check), `10m` for Hoodi
 (testnets idle and hiccup more).
 
-### F3 — Block-count constants silently break at 0.5s blocks  *(P1, fixed across PRs "block-time config" + "multicall cadence")*
+### F3 — Block-count constants silently break at 0.5s blocks  *(P1, fixed across PRs "block-time config" + "multicall cadence"; superseded by "block-subscription-refetch")*
 
 Hard-coded block *counts* that mean "~12 seconds" only at a 2s block time:
 
@@ -90,10 +98,18 @@ Hard-coded block *counts* that mean "~12 seconds" only at a 2s block time:
 | `src/lib/state/multicall.tsx` (from #44/#51) | `blocksPerFetch: 6` | refetch every 3s — 4× the RPC load |
 | `src/lib/hooks/transactions/updater.tsx` | `shouldCheck`: "every 3 blocks" / "every 10 blocks" backoff | 1.5s / 5s — hour-old stuck transactions get receipt-checked at nearly every poll, forever |
 
-**Fix**: one source of truth, `getAverageBlockTimeMs(chainId)` (2000ms for Taiko today,
+**Original fix**: one source of truth, `getAverageBlockTimeMs(chainId)` (2000ms for Taiko today,
 overridable via `REACT_APP_TAIKO_BLOCK_TIME_MS` for the 0.5s cutover), plus
-`blocksPerWindow(chainId, windowMs)`. Every block-count constant above is derived from it. When
-Taiko moves to 0.5s blocks, the cutover is an env change, not a code hunt.
+`blocksPerWindow(chainId, windowMs)`, with every block-count constant above derived from it.
+
+**Superseding fix** ("block-subscription-refetch" PR): deriving cadence from a configured block
+time still drifts whenever the chain's real cadence deviates from the table (as happened when
+Taiko moved from ~2s to ~1s blocks: the "12s" window silently became ~6s). Refetch cadence is now
+gated in **wall-clock time directly** and needs no block-time input at all: the refetch feed
+advances at most once per `DATA_REFRESH_WINDOW_MS`, the receipt-check backoff compares against a
+persisted `lastCheckedTime`, and `blocksPerFetch` is constant 1. `getAverageBlockTimeMs` /
+`blocksPerWindow` remain only for the few places that must convert a *block-number difference*
+into approximate wall time (subgraph staleness threshold, permit signature margin).
 
 ### F4 — After a confirmed transaction, balances can stay stale for up to ~12s  *(P1, fixed in PR "multicall cadence")*
 
@@ -160,10 +176,13 @@ Four principles, in priority order:
 
 1. **Steady-state cadence is a time window, not a block count.** The app refreshes chain data
    every `DATA_REFRESH_WINDOW_MS` (12s) regardless of how many blocks that spans. This is what
-   makes RPC load independent of block time (2s today, 0.5s tomorrow: same load).
-2. **Every block-count constant derives from per-chain block time.** `blocksPerWindow(chainId,
-   windowMs)` is the only allowed way to turn a time window into a block count. Block time comes
-   from one config table with an env override for cutovers.
+   makes RPC load independent of block time (1s today, 0.5s tomorrow: same load). Since the
+   "block-subscription-refetch" PR this is enforced literally: the refetch block feed
+   (`useRefetchBlockNumber`) is gated by elapsed wall time, not by counting blocks.
+2. **Block-count constants that remain derive from per-chain block time.** `blocksPerWindow(
+   chainId, windowMs)` is the only allowed way to turn a time window into a block count, and is
+   reserved for comparisons of block-number differences (e.g. subgraph staleness) — never for
+   refetch cadence, which must be gated in wall time directly.
 3. **User-action feedback bypasses the steady-state window.** Receipt polling races ahead of block
    events (F1), and a confirmed receipt snaps the multicall feed forward (F4). The user's own
    actions feel 2s-chain fast; ambient data stays 12s-window cheap.
@@ -192,6 +211,7 @@ Status as of the last update of this document:
 | 2 | **#47** — feat: per-chain block time config + fast Taiko tx confirmation (F1, F3-partial, F5) | `main` | open | New `src/config/chains/blockTime.ts` (`getAverageBlockTimeMs`, `blocksPerWindow`, `DATA_REFRESH_WINDOW_MS`, `REACT_APP_TAIKO_BLOCK_TIME_MS` override, validation, tests). Taiko receipt retry options; `shouldCheck` backoff converted from block counts to time (behavior-identical on 12s chains — unit-tested both ways). Quote-poll + permit-margin consumers moved off `AVERAGE_L1_BLOCK_TIME`; permit `now` seconds fix. |
 | 3 | **#48** — fix: surface Taiko chain stalls in minutes instead of 25 (F2, F6) | `main` | **merged** | `blockWaitMsBeforeWarning`: Taiko mainnet 3m, Hoodi 10m. `L2_CHAIN_IDS` dedupe. |
 | 4 | **#49** — refactor: derive multicall cadence from chain block time and snap to confirmed blocks (F3, F4) | #47 branch | open | `MULTICALL_BLOCK_QUANTIZATION` and `getBlocksPerFetchForChainId` derived via `blocksPerWindow` (identical values at 2s: step 6; at 0.5s: step 24 automatically). Quantizer snaps to `fastForward`ed (receipt-confirmed) blocks; `useBlockNumber` exposes the fast-forward signal. Hook-level unit tests for quantize + snap semantics. |
+| 5 | **block-subscription-refetch** — refactor: gate data refetching in wall-clock time instead of block counts | `main` | this PR | Replaces the block-count quantizer with a wall-clock gate (`useRefetchBlockNumber` in `lib/hooks/useBlockNumber.tsx`): block N adopted at time T, later blocks ignored until ≥ T + 12s; receipt snaps and reorgs cut through. Motivated by Taiko's move to ~1s blocks, which silently halved the block-count-derived window. Multicall `blocksPerFetch` → 1; multicall hooks, log fetching (`state/logs`), and position-fee simulation (`useV3PositionFees`, previously one `eth_call` per block) all keyed to the gated feed; receipt-check backoff (`shouldCheck`) converted from block-time estimates to a persisted `lastCheckedTime`; fee-tier subgraph staleness threshold time-denominated; `fastForward` made identity-stable. |
 
 **History note**: #47 and #48 were originally stacked on #44's branch, which owned
 `src/lib/state/multicall.tsx` and the only green CI toolchain while `main` failed
@@ -214,21 +234,21 @@ this document is the architecture review (§1–§3), the cutover runbook (§5),
 
 ## 5. Runbook: cutting over to 0.5s blocks
 
-When Taiko mainnet moves to ~0.5s block production:
+When Taiko mainnet moves to ~0.5s block production (updated for the "block-subscription-refetch"
+PR — the refetch cadence no longer depends on block-time configuration at all):
 
-1. Set `REACT_APP_TAIKO_BLOCK_TIME_MS=500` in the deployment environment and rebuild. Derived
-   behavior after PRs 2 & 4:
-   * multicall quantization step & `blocksPerFetch`: 6 → **24** (window stays ~12s; RPC load flat)
-   * receipt-check backoff: unchanged (time-denominated)
-   * receipt retry loop: unchanged (already sub-second)
-   * stall warning: unchanged (minutes-scale)
-2. Decide whether the product wants a faster steady-state window (e.g. 6s). If yes, change
+1. Nothing is required for data-refresh cadence: the wall-clock gate keeps the window at ~12s at
+   any block production rate, and the receipt-check backoff is persisted wall time. The receipt
+   retry loop is already sub-second and the stall warning minutes-scale.
+2. Optionally set `REACT_APP_TAIKO_BLOCK_TIME_MS=500` so the remaining block-diff↔time
+   *comparisons* stay calibrated: the fee-tier subgraph staleness threshold
+   (`useFeeTierDistribution`) and the permit signature margin (`usePermit2Allowance`). Both
+   degrade gracefully (a 2–4× staleness-tolerance skew), so this is tuning, not a cutover.
+3. Decide whether the product wants a faster steady-state window (e.g. 6s). If yes, change
    `DATA_REFRESH_WINDOW_MS` — **one constant** — with the understanding that RPC load scales
    inversely with the window.
-3. If Taiko exposes preconfirmations, see Backlog: surfacing "preconfirmed" is an additive UX
+4. If Taiko exposes preconfirmations, see Backlog: surfacing "preconfirmed" is an additive UX
    feature on top of this foundation, not a rework.
-
-No other code changes are expected. (If block time changes *again*, only the env var moves.)
 
 ---
 

--- a/src/config/chains/blockTime.ts
+++ b/src/config/chains/blockTime.ts
@@ -22,9 +22,12 @@ import { TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from './taiko'
 export const DEFAULT_AVERAGE_BLOCK_TIME_MS = 12_000
 
 /**
- * The steady-state cadence at which the interface refreshes on-chain data (multicall reads, swap
- * quotes). Block numbers are the change signal for that data, but this window is the clock:
- * pushing it lower increases RPC load proportionally on every open tab, regardless of block time.
+ * The steady-state cadence at which the interface refreshes on-chain data (multicall reads, log
+ * fetches, swap quotes). Block numbers are the change signal for that data, but this window is
+ * the clock: the block feed that drives refetching (lib/hooks/useBlockNumber's
+ * useRefetchBlockNumber) advances at most once per this many milliseconds of wall time, no matter
+ * how fast the chain produces blocks. Pushing it lower increases RPC load proportionally on every
+ * open tab, regardless of block time.
  */
 export const DATA_REFRESH_WINDOW_MS = 12_000
 
@@ -72,9 +75,12 @@ export function getAverageBlockTimeMs(chainId?: number): number {
 
 /**
  * Number of blocks the given chain is expected to produce within windowMs, as an integer >= 1.
- * This is the only sanctioned way to turn a time window into a block count (e.g. multicall's
- * blocksPerFetch), so that block-count constants keep meaning the same amount of wall time when
- * the chain's block time changes.
+ * This is the only sanctioned way to turn a time window into a block count (e.g. a "how many
+ * blocks behind the chain head may the subgraph be" staleness threshold), so that block-count
+ * constants keep meaning the same amount of wall time when the chain's block time changes.
+ * Refetch *cadence* must not be derived from it: cadence is gated in wall-clock time directly
+ * (see DATA_REFRESH_WINDOW_MS above), which stays correct even when this table's block time
+ * drifts from what the chain actually does.
  */
 export function blocksPerWindow(chainId: number | undefined, windowMs = DATA_REFRESH_WINDOW_MS): number {
   return Math.max(1, Math.round(windowMs / getAverageBlockTimeMs(chainId)))

--- a/src/hooks/useFeeTierDistribution.ts
+++ b/src/hooks/useFeeTierDistribution.ts
@@ -1,5 +1,7 @@
 import { Currency, Token } from '@uniswap/sdk-core'
 import { FeeAmount } from '@uniswap/v3-sdk'
+import { useWeb3React } from '@web3-react/core'
+import { blocksPerWindow } from 'config/chains'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import ms from 'ms'
 import { useMemo } from 'react'
@@ -7,8 +9,10 @@ import { useMemo } from 'react'
 import useFeeTierDistributionQuery from '../graphql/thegraph/FeeTierDistributionQuery'
 import { PoolState, usePool } from './usePools'
 
-// maximum number of blocks past which we consider the data stale
-const MAX_DATA_BLOCK_AGE = 20
+// Maximum wall-clock age past which we consider the subgraph data stale. Denominated in time and
+// converted to a block count per chain, so it keeps meaning the same thing as block time changes;
+// it must stay comfortably above the 30s query poll below plus normal indexing lag.
+const MAX_DATA_AGE_MS = ms(`60s`)
 
 interface FeeTierDistribution {
   isLoading: boolean
@@ -97,6 +101,7 @@ export function useFeeTierDistribution(
 }
 
 function usePoolTVL(token0: Token | undefined, token1: Token | undefined) {
+  const { chainId } = useWeb3React()
   const latestBlock = useBlockNumber()
   const { isLoading, error, data } = useFeeTierDistributionQuery(token0?.address, token1?.address, ms(`30s`))
 
@@ -110,7 +115,7 @@ function usePoolTVL(token0: Token | undefined, token1: Token | undefined) {
       }
     }
 
-    if (latestBlock - (_meta?.block?.number ?? 0) > MAX_DATA_BLOCK_AGE) {
+    if (latestBlock - (_meta?.block?.number ?? 0) > blocksPerWindow(chainId, MAX_DATA_AGE_MS)) {
       console.log(`Graph stale (latest block: ${latestBlock})`)
       return {
         isLoading,
@@ -197,5 +202,5 @@ function usePoolTVL(token0: Token | undefined, token1: Token | undefined) {
       error,
       distributions,
     }
-  }, [_meta, asToken0, asToken1, isLoading, error, latestBlock])
+  }, [_meta, asToken0, asToken1, chainId, isLoading, error, latestBlock])
 }

--- a/src/hooks/usePoolTickData.ts
+++ b/src/hooks/usePoolTickData.ts
@@ -33,8 +33,6 @@ export interface TickProcessed {
   price0: string
 }
 
-const REFRESH_FREQUENCY = { blocksPerFetch: 2 }
-
 const getActiveTick = (tickCurrent: number | undefined, feeAmount: FeeAmount | undefined) =>
   tickCurrent && feeAmount ? Math.floor(tickCurrent / TICK_SPACINGS[feeAmount]) * TICK_SPACINGS[feeAmount] : undefined
 
@@ -96,11 +94,12 @@ function useTicksFromTickLens(
   )
 
   const tickLens = useTickLens()
+  // Refresh cadence comes from the wall-clock-gated multicall feed (one refetch per data refresh
+  // window); a block-denominated override here would only skip windows on a fast chain.
   const callStates = useSingleContractMultipleData(
     tickLensArgs.length > 0 ? tickLens : undefined,
     'getPopulatedTicksInWord',
-    tickLensArgs,
-    REFRESH_FREQUENCY
+    tickLensArgs
   )
 
   const isError = useMemo(() => callStates.some(({ error }) => error), [callStates])

--- a/src/hooks/useV3PositionFees.ts
+++ b/src/hooks/useV3PositionFees.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { Pool } from '@uniswap/v3-sdk'
 import { useSingleCallResult } from 'lib/hooks/multicall'
-import useBlockNumber from 'lib/hooks/useBlockNumber'
+import { useRefetchBlockNumber } from 'lib/hooks/useBlockNumber'
 import { useEffect, useState } from 'react'
 import { unwrappedToken } from 'utils/unwrappedToken'
 
@@ -21,10 +21,12 @@ export function useV3PositionFees(
     .result?.[0]
 
   const tokenIdHexString = tokenId?.toHexString()
-  const latestBlockNumber = useBlockNumber()
+  // Keyed on the wall-clock-gated feed, not the raw one: this effect runs an eth_call per change,
+  // which on a ~1s-block chain would mean one RPC round per second per open position.
+  const latestBlockNumber = useRefetchBlockNumber()
 
   // we can't use multicall for this because we need to simulate the call from a specific address
-  // latestBlockNumber is included to ensure data stays up-to-date every block
+  // latestBlockNumber is included to ensure data stays up-to-date as the chain advances
   const [amounts, setAmounts] = useState<[BigNumber, BigNumber] | undefined>()
   useEffect(() => {
     ;(async function getFees() {

--- a/src/lib/hooks/multicall.ts
+++ b/src/lib/hooks/multicall.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import useBlockNumber, { useMainnetBlockNumber } from 'lib/hooks/useBlockNumber'
+import { useMainnetRefetchBlockNumber, useRefetchBlockNumber } from 'lib/hooks/useBlockNumber'
 import multicall from 'lib/state/multicall'
 import { SkipFirst } from 'types/tuple'
 
@@ -24,7 +24,7 @@ export function useSingleCallResult(...args: SkipFirstTwoParams<typeof multicall
 }
 
 export function useMainnetSingleCallResult(...args: SkipFirstTwoParams<typeof multicall.hooks.useSingleCallResult>) {
-  const latestMainnetBlock = useMainnetBlockNumber()
+  const latestMainnetBlock = useMainnetRefetchBlockNumber()
   return multicall.hooks.useSingleCallResult(ChainId.MAINNET, latestMainnetBlock, ...args)
 }
 
@@ -37,6 +37,9 @@ export function useSingleContractMultipleData(
 
 function useCallContext() {
   const { chainId } = useWeb3React()
-  const latestBlock = useBlockNumber()
+  // The block fed to the hooks must be the one that drives the MulticallUpdater's fetches: the
+  // hooks compare each result's block against it to derive `valid`/`syncing`, so feeding them
+  // the raw per-block feed on a ~1s chain would mark every result out of sync ~always.
+  const latestBlock = useRefetchBlockNumber()
   return { chainId, latestBlock }
 }

--- a/src/lib/hooks/transactions/updater.test.tsx
+++ b/src/lib/hooks/transactions/updater.test.tsx
@@ -18,65 +18,55 @@ describe('transactions updater', () => {
     it('returns false if has receipt and never checked', () => {
       expect(shouldCheck(10, { addedTime: 100, receipt: {} })).toEqual(false)
     })
-    it('returns true if has not been checked in 1 blocks', () => {
-      expect(shouldCheck(10, { addedTime: new Date().getTime(), lastCheckedBlockNumber: 9 })).toEqual(true)
+    it('returns true for a fresh transaction on every new block', () => {
+      const now = Date.now()
+      expect(shouldCheck(10, { addedTime: now, lastCheckedBlockNumber: 9, lastCheckedTime: now })).toEqual(true)
     })
-    it('returns false if checked in last 3 blocks and greater than 20 minutes old', () => {
-      expect(shouldCheck(10, { addedTime: new Date().getTime() - 21 * 60 * 1000, lastCheckedBlockNumber: 8 })).toEqual(
-        false
-      )
-    })
-    it('returns true if not checked in last 5 blocks and greater than 20 minutes old', () => {
-      expect(shouldCheck(10, { addedTime: new Date().getTime() - 21 * 60 * 1000, lastCheckedBlockNumber: 5 })).toEqual(
-        true
-      )
-    })
-    it('returns false if checked in last 10 blocks and greater than 60 minutes old', () => {
-      expect(shouldCheck(20, { addedTime: new Date().getTime() - 61 * 60 * 1000, lastCheckedBlockNumber: 11 })).toEqual(
-        false
-      )
-    })
-    it('returns true if checked in last 3 blocks and greater than 60 minutes old', () => {
-      expect(shouldCheck(20, { addedTime: new Date().getTime() - 61 * 60 * 1000, lastCheckedBlockNumber: 10 })).toEqual(
-        true
-      )
+    it('returns false when no new block has been produced since the last check', () => {
+      // Regardless of how much wall time passed: without a new block there is nothing new to see.
+      const tx = { addedTime: Date.now() - 61 * 60 * 1000, lastCheckedBlockNumber: 10, lastCheckedTime: 0 }
+      expect(shouldCheck(10, tx)).toEqual(false)
+      expect(shouldCheck(9, tx)).toEqual(false)
     })
 
-    describe('with a 2s block time (Taiko today)', () => {
-      const BLOCK_TIME = 2_000
-      it('checks fresh transactions on every new block', () => {
-        expect(shouldCheck(100, { addedTime: new Date().getTime(), lastCheckedBlockNumber: 99 }, BLOCK_TIME)).toEqual(
-          true
-        )
-      })
-      it('backs off to ~36s when pending longer than 5 minutes', () => {
-        const addedTime = new Date().getTime() - 21 * 60 * 1000
-        // 17 blocks * 2s = 34s: too soon. 18 blocks * 2s = 36s: due.
-        expect(shouldCheck(100, { addedTime, lastCheckedBlockNumber: 83 }, BLOCK_TIME)).toEqual(false)
-        expect(shouldCheck(100, { addedTime, lastCheckedBlockNumber: 82 }, BLOCK_TIME)).toEqual(true)
-      })
-      it('backs off to ~2m when pending longer than an hour', () => {
-        const addedTime = new Date().getTime() - 61 * 60 * 1000
-        // 59 blocks * 2s = 118s: too soon. 60 blocks * 2s = 120s: due.
-        expect(shouldCheck(100, { addedTime, lastCheckedBlockNumber: 41 }, BLOCK_TIME)).toEqual(false)
-        expect(shouldCheck(100, { addedTime, lastCheckedBlockNumber: 40 }, BLOCK_TIME)).toEqual(true)
+    // The backoff for long-pending transactions is denominated purely in wall time since the
+    // last check, so it is independent of the chain's block cadence (1s, 2s, or 0.5s blocks).
+    describe('pending longer than 5 minutes', () => {
+      const addedTime = () => Date.now() - 21 * 60 * 1000
+      it('backs off until ~36s since the last check', () => {
+        expect(
+          shouldCheck(100, { addedTime: addedTime(), lastCheckedBlockNumber: 99, lastCheckedTime: Date.now() - 35_999 })
+        ).toEqual(false)
+        expect(
+          shouldCheck(100, { addedTime: addedTime(), lastCheckedBlockNumber: 99, lastCheckedTime: Date.now() - 36_000 })
+        ).toEqual(true)
       })
     })
 
-    describe('with a 0.5s block time (Taiko roadmap)', () => {
-      const BLOCK_TIME = 500
-      it('backs off to ~36s when pending longer than 5 minutes', () => {
-        const addedTime = new Date().getTime() - 21 * 60 * 1000
-        // 71 blocks * 0.5s = 35.5s: too soon. 72 blocks * 0.5s = 36s: due.
-        expect(shouldCheck(1000, { addedTime, lastCheckedBlockNumber: 929 }, BLOCK_TIME)).toEqual(false)
-        expect(shouldCheck(1000, { addedTime, lastCheckedBlockNumber: 928 }, BLOCK_TIME)).toEqual(true)
+    describe('pending longer than an hour', () => {
+      const addedTime = () => Date.now() - 61 * 60 * 1000
+      it('backs off until ~2m since the last check', () => {
+        expect(
+          shouldCheck(100, {
+            addedTime: addedTime(),
+            lastCheckedBlockNumber: 99,
+            lastCheckedTime: Date.now() - 119_999,
+          })
+        ).toEqual(false)
+        expect(
+          shouldCheck(100, {
+            addedTime: addedTime(),
+            lastCheckedBlockNumber: 99,
+            lastCheckedTime: Date.now() - 120_000,
+          })
+        ).toEqual(true)
       })
-      it('backs off to ~2m when pending longer than an hour', () => {
-        const addedTime = new Date().getTime() - 61 * 60 * 1000
-        // 239 blocks * 0.5s = 119.5s: too soon. 240 blocks * 0.5s = 120s: due.
-        expect(shouldCheck(1000, { addedTime, lastCheckedBlockNumber: 761 }, BLOCK_TIME)).toEqual(false)
-        expect(shouldCheck(1000, { addedTime, lastCheckedBlockNumber: 760 }, BLOCK_TIME)).toEqual(true)
-      })
+    })
+
+    it('treats transactions persisted before lastCheckedTime existed as due', () => {
+      // Old localStorage state has lastCheckedBlockNumber but no lastCheckedTime; the first
+      // check after upgrade stamps it.
+      expect(shouldCheck(100, { addedTime: Date.now() - 61 * 60 * 1000, lastCheckedBlockNumber: 50 })).toEqual(true)
     })
   })
 })

--- a/src/lib/hooks/transactions/updater.tsx
+++ b/src/lib/hooks/transactions/updater.tsx
@@ -1,12 +1,7 @@
 import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { ChainId } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import {
-  DEFAULT_AVERAGE_BLOCK_TIME_MS,
-  getAverageBlockTimeMs,
-  TAIKO_HOODI_CHAIN_ID,
-  TAIKO_MAINNET_CHAIN_ID,
-} from 'config/chains'
+import { TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
 import useCurrentBlockTimestamp from 'hooks/useCurrentBlockTimestamp'
 import useBlockNumber, { useFastForwardBlockNumber } from 'lib/hooks/useBlockNumber'
 import ms from 'ms'
@@ -20,30 +15,29 @@ interface Transaction {
   addedTime: number
   receipt?: unknown
   lastCheckedBlockNumber?: number
+  lastCheckedTime?: number
 }
 
-export function shouldCheck(
-  lastBlockNumber: number,
-  tx: Transaction,
-  averageBlockTimeMs = DEFAULT_AVERAGE_BLOCK_TIME_MS
-): boolean {
+export function shouldCheck(lastBlockNumber: number, tx: Transaction): boolean {
   if (tx.receipt) return false
   if (!tx.lastCheckedBlockNumber) return true
   const blocksSinceCheck = lastBlockNumber - tx.lastCheckedBlockNumber
   if (blocksSinceCheck < 1) return false
-  // Back off in wall time, not block counts: on a 2s (or 0.5s) chain a fixed block count would
-  // shrink to a couple of seconds and long-pending transactions would be re-checked on nearly
-  // every block event, forever.
-  const msSinceCheck = blocksSinceCheck * averageBlockTimeMs
-  const minutesPending = (new Date().getTime() - tx.addedTime) / ms(`1m`)
+  // Back off in wall time, not block counts: on a chain producing a block every second or two, a
+  // fixed block count would shrink to a couple of seconds and long-pending transactions would be
+  // re-checked on nearly every block event, forever. Transactions persisted before
+  // lastCheckedTime existed are treated as due now; the first check stamps them.
+  const msSinceCheck = tx.lastCheckedTime === undefined ? Infinity : Date.now() - tx.lastCheckedTime
+  const minutesPending = (Date.now() - tx.addedTime) / ms(`1m`)
   if (minutesPending > 60) {
-    // at most every ~2m (10 L1 blocks) if pending longer than an hour
+    // at most every ~2m if pending longer than an hour
     return msSinceCheck >= ms(`2m`)
   } else if (minutesPending > 5) {
-    // at most every ~36s (3 L1 blocks) if pending longer than 5 minutes
+    // at most every ~36s if pending longer than 5 minutes
     return msSinceCheck >= ms(`36s`)
   } else {
-    // otherwise on every new block
+    // otherwise on every new block: a transaction the user just submitted must confirm as fast
+    // as the chain does, so recency of feedback deliberately beats the steady-state data window
     return true
   }
 }
@@ -110,7 +104,7 @@ export default function Updater({ pendingTransactions, onCheck, onReceipt }: Upd
     if (!chainId || !provider || !lastBlockNumber) return
 
     const cancels = Object.keys(pendingTransactions)
-      .filter((hash) => shouldCheck(lastBlockNumber, pendingTransactions[hash], getAverageBlockTimeMs(chainId)))
+      .filter((hash) => shouldCheck(lastBlockNumber, pendingTransactions[hash]))
       .map((hash) => {
         const { promise, cancel } = getReceipt(hash)
         promise

--- a/src/lib/hooks/useBlockNumber.test.tsx
+++ b/src/lib/hooks/useBlockNumber.test.tsx
@@ -1,10 +1,15 @@
 import { useWeb3React } from '@web3-react/core'
-import { TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
+import { DATA_REFRESH_WINDOW_MS, TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
 import { EventEmitter } from 'events'
 import { mocked } from 'test-utils/mocked'
 import { act, renderHook } from 'test-utils/render'
 
-import useBlockNumber, { useFastForwardBlockNumber, useFastForwardedBlockNumber } from './useBlockNumber'
+import useBlockNumber, {
+  useFastForwardBlockNumber,
+  useFastForwardedBlockNumber,
+  useRefetchBlockNumber,
+  useTimeGatedBlockNumber,
+} from './useBlockNumber'
 
 // Far above any real Taiko block number, so the ambient mainnet-block fetch through the real
 // RPC provider (swallowed in tests, but potentially resolving on CI runners with open network)
@@ -103,5 +108,178 @@ describe('BlockNumberProvider', () => {
     // A block from the old chain is meaningless on the new one.
     expect(result.current.fastForwarded).toBeUndefined()
     expect(result.current.block).toEqual(OTHER_CHAIN_BLOCK)
+  })
+})
+
+describe('useTimeGatedBlockNumber', () => {
+  const CHAIN_A = TAIKO_MAINNET_CHAIN_ID
+  const CHAIN_B = TAIKO_HOODI_CHAIN_ID
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function renderGated(initial: { chainId?: number; blockNumber?: number; snapTo?: number }) {
+    return renderHook(
+      ({ chainId, blockNumber, snapTo }: { chainId?: number; blockNumber?: number; snapTo?: number }) =>
+        useTimeGatedBlockNumber(chainId ?? CHAIN_A, blockNumber, snapTo),
+      { initialProps: initial }
+    )
+  }
+
+  it('is undefined until a block number arrives, then adopts it', () => {
+    const { result, rerender } = renderGated({ blockNumber: undefined })
+    expect(result.current).toBeUndefined()
+    rerender({ blockNumber: 100 })
+    expect(result.current).toEqual(100)
+  })
+
+  it('holds new blocks within the refresh window and advances once it has elapsed', () => {
+    const { result, rerender } = renderGated({ blockNumber: 100 })
+    jest.advanceTimersByTime(DATA_REFRESH_WINDOW_MS - 1)
+    rerender({ blockNumber: 101 })
+    rerender({ blockNumber: 105 })
+    expect(result.current).toEqual(100) // window not elapsed: hold
+    jest.advanceTimersByTime(1)
+    rerender({ blockNumber: 106 })
+    expect(result.current).toEqual(106) // window elapsed: advance
+    jest.advanceTimersByTime(DATA_REFRESH_WINDOW_MS - 1)
+    rerender({ blockNumber: 118 })
+    expect(result.current).toEqual(106) // the next window is measured from the adoption
+  })
+
+  it('advances on the first block after a stall longer than the window', () => {
+    const { result, rerender } = renderGated({ blockNumber: 100 })
+    // No new blocks for several windows (chain stall or provider hiccup): the first block to
+    // arrive afterwards is adopted immediately rather than waiting out another window.
+    jest.advanceTimersByTime(3 * DATA_REFRESH_WINDOW_MS)
+    rerender({ blockNumber: 101 })
+    expect(result.current).toEqual(101)
+  })
+
+  it('adopts a lower block number immediately and restarts the window (reorg)', () => {
+    const { result, rerender } = renderGated({ blockNumber: 100 })
+    jest.advanceTimersByTime(DATA_REFRESH_WINDOW_MS - 1)
+    rerender({ blockNumber: 50 })
+    expect(result.current).toEqual(50)
+    // The reorg adoption restarted the clock: a higher block right after it still holds.
+    jest.advanceTimersByTime(DATA_REFRESH_WINDOW_MS - 1)
+    rerender({ blockNumber: 60 })
+    expect(result.current).toEqual(50)
+    jest.advanceTimersByTime(1)
+    rerender({ blockNumber: 61 })
+    expect(result.current).toEqual(61)
+  })
+
+  it('returns undefined while the new chain block is still unknown after a chain switch', () => {
+    const { result, rerender } = renderGated({ chainId: CHAIN_A, blockNumber: 100 })
+    expect(result.current).toEqual(100)
+    // The chain switched but its first block has not arrived yet: the old
+    // chain's number must not leak to the new chain's consumers.
+    rerender({ chainId: CHAIN_B, blockNumber: undefined })
+    expect(result.current).toBeUndefined()
+  })
+
+  it("adopts the new chain's first block even within the old chain's window", () => {
+    const { result, rerender } = renderGated({ chainId: CHAIN_A, blockNumber: 100 })
+    // Immediately after: on the same chain the window would hold, but on a new chain it is the
+    // first observation and must be adopted.
+    rerender({ chainId: CHAIN_B, blockNumber: 102 })
+    expect(result.current).toEqual(102)
+  })
+
+  it('snaps forward to a receipt-confirmed block inside the window', () => {
+    const { result, rerender } = renderGated({ blockNumber: 100 })
+    jest.advanceTimersByTime(1_000)
+    rerender({ blockNumber: 102 })
+    expect(result.current).toEqual(100)
+    // The user's transaction confirmed in block 102: refresh immediately.
+    rerender({ blockNumber: 102, snapTo: 102 })
+    expect(result.current).toEqual(102)
+    // The next steady-state advance is measured from the snap.
+    jest.advanceTimersByTime(DATA_REFRESH_WINDOW_MS - 1)
+    rerender({ blockNumber: 107, snapTo: 102 })
+    expect(result.current).toEqual(102)
+    jest.advanceTimersByTime(1)
+    rerender({ blockNumber: 108, snapTo: 102 })
+    expect(result.current).toEqual(108)
+  })
+
+  it('snaps even when the receipt block is ahead of the raw feed', () => {
+    // Receipts can reference blocks the polled feed has not seen yet.
+    const { result, rerender } = renderGated({ blockNumber: 100 })
+    rerender({ blockNumber: 100, snapTo: 103 })
+    expect(result.current).toEqual(103)
+  })
+
+  it('ignores snaps at or behind the gated block', () => {
+    const { result, rerender } = renderGated({ blockNumber: 100 })
+    rerender({ blockNumber: 100, snapTo: 100 })
+    expect(result.current).toEqual(100)
+    rerender({ blockNumber: 100, snapTo: 99 })
+    expect(result.current).toEqual(100)
+  })
+
+  it('does not resurrect a stale snap after moving to a lower block (reorg)', () => {
+    const { result, rerender } = renderGated({ blockNumber: 100, snapTo: 102 })
+    expect(result.current).toEqual(102)
+    rerender({ blockNumber: 50, snapTo: undefined })
+    expect(result.current).toEqual(50)
+  })
+
+  it('does not carry a snap across a chain switch', () => {
+    const { result, rerender } = renderGated({ chainId: CHAIN_A, blockNumber: 100, snapTo: 102 })
+    expect(result.current).toEqual(102)
+    rerender({ chainId: CHAIN_B, blockNumber: undefined, snapTo: undefined })
+    expect(result.current).toBeUndefined()
+  })
+})
+
+describe('useRefetchBlockNumber', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function renderFeeds() {
+    return renderHook(() => ({
+      block: useBlockNumber(),
+      refetchBlock: useRefetchBlockNumber(),
+      fastForward: useFastForwardBlockNumber(),
+    }))
+  }
+
+  it('lags the raw feed by the refresh window and snaps to confirmed receipts', async () => {
+    const provider = new FakeProvider(BLOCK)
+    mockChain(TAIKO_MAINNET_CHAIN_ID, provider)
+    const { result } = renderFeeds()
+    await act(async () => undefined) // flush the initial getBlockNumber()
+    expect(result.current.refetchBlock).toEqual(BLOCK)
+
+    // Blocks arriving within the window move the raw feed but not the refetch feed.
+    act(() => {
+      provider.emit('block', BLOCK + 1)
+      provider.emit('block', BLOCK + 2)
+    })
+    expect(result.current.block).toEqual(BLOCK + 2)
+    expect(result.current.refetchBlock).toEqual(BLOCK)
+
+    // A receipt for one of the user's own transactions cuts through the window.
+    act(() => {
+      result.current.fastForward(BLOCK + 2)
+    })
+    expect(result.current.refetchBlock).toEqual(BLOCK + 2)
+
+    // Once the window (restarted by the snap) elapses, the next block is adopted.
+    act(() => {
+      jest.advanceTimersByTime(DATA_REFRESH_WINDOW_MS)
+      provider.emit('block', BLOCK + 14)
+    })
+    expect(result.current.refetchBlock).toEqual(BLOCK + 14)
   })
 })

--- a/src/lib/hooks/useBlockNumber.tsx
+++ b/src/lib/hooks/useBlockNumber.tsx
@@ -1,5 +1,5 @@
 import { useWeb3React } from '@web3-react/core'
-import { TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
+import { DATA_REFRESH_WINDOW_MS, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
 import { RPC_PROVIDERS } from 'constants/providers'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
@@ -11,6 +11,8 @@ const BlockNumberContext = createContext<
       block?: number
       mainnetBlock?: number
       fastForwardedBlock?: number
+      refetchBlock?: number
+      mainnetRefetchBlock?: number
     }
   | typeof MISSING_PROVIDER
 >(MISSING_PROVIDER)
@@ -32,18 +34,77 @@ export default function useBlockNumber(): number | undefined {
   return useBlockNumberContext().block
 }
 
-export function useMainnetBlockNumber(): number | undefined {
-  return useBlockNumberContext().mainnetBlock
-}
-
 /**
  * The highest block number observed via a confirmed transaction receipt on the active chain
  * (see useFastForwardBlockNumber). Unlike the raw block feed, this only moves when one of the
  * user's own transactions confirms, so consumers that deliberately lag the raw feed (e.g. the
- * quantized multicall feed) can use it to refresh immediately after a user action.
+ * refetch feed below) can use it to refresh immediately after a user action.
  */
 export function useFastForwardedBlockNumber(): number | undefined {
   return useBlockNumberContext().fastForwardedBlock
+}
+
+/**
+ * The block number chain-data refetching should key on. Unlike the raw feed, which moves on
+ * every block the provider reports (~every second on Taiko), this advances at most once per
+ * DATA_REFRESH_WINDOW_MS of wall-clock time: when block N is adopted at time T, later blocks are
+ * ignored until a block arrives at or after T + DATA_REFRESH_WINDOW_MS. Anything keyed on it
+ * (multicall reads, log fetches, position-fee simulations) therefore refetches on a fixed time
+ * budget no matter how fast the chain produces blocks.
+ *
+ * Two events cut through the window, because waiting would show the user wrong data:
+ * - a receipt for one of the user's own transactions (useFastForwardBlockNumber) proves state
+ *   relevant to them changed, and snaps this feed to the receipt's block immediately;
+ * - a lower block number (reorg) is adopted immediately.
+ * Both also restart the window from the moment they are adopted.
+ */
+export function useRefetchBlockNumber(): number | undefined {
+  return useBlockNumberContext().refetchBlock
+}
+
+/** The Taiko-mainnet counterpart of useRefetchBlockNumber, independent of the wallet's chain. */
+export function useMainnetRefetchBlockNumber(): number | undefined {
+  return useBlockNumberContext().mainnetRefetchBlock
+}
+
+// The wall-clock gate behind useRefetchBlockNumber. The gated value is keyed by `chainId`: block
+// numbers from different chains are not comparable, so after a chain switch this returns
+// undefined until the new chain's feed produces a block (adopted directly, so a fresh page or
+// chain never waits out a window for its first data), rather than leaking the previous chain's
+// number to the new chain's consumers. Exported for testing.
+export function useTimeGatedBlockNumber(
+  chainId: number | undefined,
+  blockNumber: number | undefined,
+  snapTo?: number
+): number | undefined {
+  const [gated, setGated] = useState<{ chainId?: number; block?: number; adoptedAtMs?: number }>({})
+  useEffect(() => {
+    if (chainId === undefined || blockNumber === undefined) return
+    setGated((prev) => {
+      // The first block observed for a chain is adopted directly; afterwards advance only when
+      // the refresh window has elapsed since the last adoption, and take the new number directly
+      // if it moved backwards (reorg).
+      if (
+        prev.chainId !== chainId ||
+        prev.block === undefined ||
+        prev.adoptedAtMs === undefined ||
+        blockNumber < prev.block ||
+        (blockNumber > prev.block && Date.now() - prev.adoptedAtMs >= DATA_REFRESH_WINDOW_MS)
+      ) {
+        return { chainId, block: blockNumber, adoptedAtMs: Date.now() }
+      }
+      return prev
+    })
+  }, [chainId, blockNumber])
+  useEffect(() => {
+    if (chainId === undefined || snapTo === undefined) return
+    setGated((prev) =>
+      prev.chainId === chainId && prev.block !== undefined && snapTo <= prev.block
+        ? prev
+        : { chainId, block: snapTo, adoptedAtMs: Date.now() }
+    )
+  }, [chainId, snapTo])
+  return gated.chainId === chainId ? gated.block : undefined
 }
 
 export function BlockNumberProvider({ children }: { children: ReactNode }) {
@@ -56,6 +117,16 @@ export function BlockNumberProvider({ children }: { children: ReactNode }) {
   const activeBlock = chainId === activeChainId ? block : undefined
   const [fastForwarded, setFastForwarded] = useState<{ chainId: number; block: number }>()
   const fastForwardedBlock = fastForwarded && fastForwarded.chainId === activeChainId ? fastForwarded.block : undefined
+
+  // Wall-clock-gated feeds for data refetching (see useRefetchBlockNumber). In this Taiko-only
+  // fork the "mainnet" feed carries Taiko mainnet blocks no matter which chain the wallet is on,
+  // so it gates and snaps on its own clock, keyed to Taiko mainnet.
+  const refetchBlock = useTimeGatedBlockNumber(activeChainId, activeBlock, fastForwardedBlock)
+  const mainnetRefetchBlock = useTimeGatedBlockNumber(
+    TAIKO_MAINNET_CHAIN_ID,
+    mainnetBlock,
+    activeChainId === TAIKO_MAINNET_CHAIN_ID ? fastForwardedBlock : undefined
+  )
 
   const onChainBlock = useCallback((chainId: number, block: number) => {
     setChainBlock((chainBlock) => {
@@ -116,30 +187,42 @@ export function BlockNumberProvider({ children }: { children: ReactNode }) {
     }
   }, [mainnetBlock, onChainBlock])
 
-  const value = useMemo(
-    () => ({
-      fastForward: (update: number) => {
-        // Record the receipt-confirmed block even when it does not advance the raw feed (the
-        // block event may already have arrived): the raw feed only proves a block exists, while
-        // this proves the user's own state changed in it. See useFastForwardedBlockNumber.
-        if (activeChainId) {
-          setFastForwarded((prev) =>
-            prev?.chainId === activeChainId && prev.block >= update ? prev : { chainId: activeChainId, block: update }
-          )
-        }
-        if (activeBlock && update > activeBlock) {
-          setChainBlock({
+  // Kept identity-stable (only the chain id can invalidate it): consumers key effects on it, and
+  // an identity that churned with every block state update would cancel and restart their
+  // in-flight work (e.g. the transaction updater's receipt retry loop) once per block event.
+  const fastForward = useCallback(
+    (update: number) => {
+      if (!activeChainId) return
+      // Record the receipt-confirmed block even when it does not advance the raw feed (the
+      // block event may already have arrived): the raw feed only proves a block exists, while
+      // this proves the user's own state changed in it. See useFastForwardedBlockNumber.
+      setFastForwarded((prev) =>
+        prev?.chainId === activeChainId && prev.block >= update ? prev : { chainId: activeChainId, block: update }
+      )
+      setChainBlock((chainBlock) => {
+        if (chainBlock.chainId === activeChainId && chainBlock.block && update > chainBlock.block) {
+          return {
             chainId: activeChainId,
             block: update,
-            mainnetBlock: activeChainId === TAIKO_MAINNET_CHAIN_ID ? update : mainnetBlock,
-          })
+            mainnetBlock: activeChainId === TAIKO_MAINNET_CHAIN_ID ? update : chainBlock.mainnetBlock,
+          }
         }
-      },
+        return chainBlock
+      })
+    },
+    [activeChainId]
+  )
+
+  const value = useMemo(
+    () => ({
+      fastForward,
       block: activeBlock,
       mainnetBlock,
       fastForwardedBlock,
+      refetchBlock,
+      mainnetRefetchBlock,
     }),
-    [activeBlock, activeChainId, fastForwardedBlock, mainnetBlock]
+    [activeBlock, fastForward, fastForwardedBlock, mainnetBlock, mainnetRefetchBlock, refetchBlock]
   )
   return <BlockNumberContext.Provider value={value}>{children}</BlockNumberContext.Provider>
 }

--- a/src/lib/state/multicall.test.tsx
+++ b/src/lib/state/multicall.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react'
 import { ChainId } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import { TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
+import { DATA_REFRESH_WINDOW_MS, TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
 import { EventEmitter } from 'events'
 import { useFastForwardBlockNumber } from 'lib/hooks/useBlockNumber'
 import { useEffect, useState } from 'react'
@@ -9,7 +9,7 @@ import store from 'state'
 import { mocked } from 'test-utils/mocked'
 import { act, render } from 'test-utils/render'
 
-import multicall, { MulticallUpdater, useQuantizedBlockNumber, useSettledBlockNumber } from './multicall'
+import multicall, { MulticallUpdater, useSettledBlockNumber } from './multicall'
 
 jest.mock('hooks/useContract', () => {
   const useContract = jest.requireActual('hooks/useContract')
@@ -21,26 +21,8 @@ jest.mock('hooks/useContract', () => {
   }
 })
 
-const STEP = 6
 const CHAIN_A = TAIKO_MAINNET_CHAIN_ID
 const CHAIN_B = TAIKO_HOODI_CHAIN_ID
-
-function renderQuantized(initial: { chainId?: number; blockNumber?: number; step?: number; snapTo?: number }) {
-  return renderHook(
-    ({
-      chainId,
-      blockNumber,
-      step,
-      snapTo,
-    }: {
-      chainId?: number
-      blockNumber?: number
-      step?: number
-      snapTo?: number
-    }) => useQuantizedBlockNumber(chainId ?? CHAIN_A, blockNumber, step ?? STEP, snapTo),
-    { initialProps: initial }
-  )
-}
 
 function renderSettled(initial: { chainId?: number; blockNumber?: number; isFetching?: boolean }) {
   return renderHook(
@@ -49,92 +31,6 @@ function renderSettled(initial: { chainId?: number; blockNumber?: number; isFetc
     { initialProps: initial }
   )
 }
-
-describe('useQuantizedBlockNumber', () => {
-  it('is undefined until a block number arrives, then adopts it', () => {
-    const { result, rerender } = renderQuantized({ blockNumber: undefined })
-    expect(result.current).toBeUndefined()
-    rerender({ blockNumber: 100 })
-    expect(result.current).toEqual(100)
-  })
-
-  it('holds within a window and advances once a full step has passed', () => {
-    const { result, rerender } = renderQuantized({ blockNumber: 100 })
-    rerender({ blockNumber: 101 })
-    rerender({ blockNumber: 105 })
-    expect(result.current).toEqual(100) // < step ahead: hold
-    rerender({ blockNumber: 106 })
-    expect(result.current).toEqual(106) // step reached: advance
-    rerender({ blockNumber: 111 })
-    expect(result.current).toEqual(106) // next window starts from the adopted block
-  })
-
-  it('adopts a lower block number immediately (reorg)', () => {
-    const { result, rerender } = renderQuantized({ blockNumber: 100 })
-    rerender({ blockNumber: 50 })
-    expect(result.current).toEqual(50)
-  })
-
-  it('returns undefined while the new chain block is still unknown after a chain switch', () => {
-    const { result, rerender } = renderQuantized({ chainId: CHAIN_A, blockNumber: 100 })
-    expect(result.current).toEqual(100)
-    // The chain switched but its first block has not arrived yet: the old
-    // chain's number must not leak to the new chain's updater.
-    rerender({ chainId: CHAIN_B, blockNumber: undefined })
-    expect(result.current).toBeUndefined()
-  })
-
-  it("adopts the new chain's first block even when it is within a step of the old value", () => {
-    const { result, rerender } = renderQuantized({ chainId: CHAIN_A, blockNumber: 100 })
-    // 102 is < one step ahead of 100 - on the same chain it would hold, but on
-    // a new chain it is the first observation and must be adopted.
-    rerender({ chainId: CHAIN_B, blockNumber: 102 })
-    expect(result.current).toEqual(102)
-  })
-
-  it('snaps forward to a receipt-confirmed block inside the window', () => {
-    const { result, rerender } = renderQuantized({ blockNumber: 100 })
-    rerender({ blockNumber: 102 })
-    expect(result.current).toEqual(100)
-    // The user's transaction confirmed in block 102: refresh immediately.
-    rerender({ blockNumber: 102, snapTo: 102 })
-    expect(result.current).toEqual(102)
-    // The next steady-state advance is measured from the snapped block.
-    rerender({ blockNumber: 107, snapTo: 102 })
-    expect(result.current).toEqual(102)
-    rerender({ blockNumber: 108, snapTo: 102 })
-    expect(result.current).toEqual(108)
-  })
-
-  it('snaps even when the receipt block is ahead of the raw feed', () => {
-    // Receipts can reference blocks the polled feed has not seen yet.
-    const { result, rerender } = renderQuantized({ blockNumber: 100 })
-    rerender({ blockNumber: 100, snapTo: 103 })
-    expect(result.current).toEqual(103)
-  })
-
-  it('ignores snaps at or behind the quantized block', () => {
-    const { result, rerender } = renderQuantized({ blockNumber: 100 })
-    rerender({ blockNumber: 100, snapTo: 100 })
-    expect(result.current).toEqual(100)
-    rerender({ blockNumber: 100, snapTo: 99 })
-    expect(result.current).toEqual(100)
-  })
-
-  it('does not resurrect a stale snap after moving to a lower block (reorg)', () => {
-    const { result, rerender } = renderQuantized({ blockNumber: 100, snapTo: 102 })
-    expect(result.current).toEqual(102)
-    rerender({ blockNumber: 50, snapTo: undefined })
-    expect(result.current).toEqual(50)
-  })
-
-  it('does not carry a snap across a chain switch', () => {
-    const { result, rerender } = renderQuantized({ chainId: CHAIN_A, blockNumber: 100, snapTo: 102 })
-    expect(result.current).toEqual(102)
-    rerender({ chainId: CHAIN_B, blockNumber: undefined, snapTo: undefined })
-    expect(result.current).toBeUndefined()
-  })
-})
 
 describe('useSettledBlockNumber', () => {
   it('adopts desired blocks while idle', () => {
@@ -213,6 +109,7 @@ describe('MulticallUpdater', () => {
 
   let updaterSpy: jest.SpyInstance
   beforeEach(() => {
+    jest.useFakeTimers()
     updaterSpy = jest.spyOn(multicall, 'Updater').mockImplementation(() => <></>)
   })
   afterEach(() => {
@@ -234,6 +131,7 @@ describe('MulticallUpdater', () => {
       )
     })
     updaterSpy.mockRestore()
+    jest.useRealTimers()
   })
 
   function markFetching(chainId: number, call: typeof ACTIVE_CALL, blockNumber: number) {
@@ -278,18 +176,29 @@ describe('MulticallUpdater', () => {
     )
   }
 
-  it('feeds Taiko mainnet updaters a quantized feed that snaps to confirmed receipts', async () => {
+  /** Elapses a full data refresh window and delivers the next block event. */
+  function elapseWindowTo(provider: FakeProvider, block: number) {
+    act(() => {
+      jest.advanceTimersByTime(DATA_REFRESH_WINDOW_MS)
+      provider.emit('block', block)
+    })
+  }
+
+  it('feeds Taiko mainnet updaters a wall-clock-gated feed that snaps to confirmed receipts', async () => {
     const provider = new FakeProvider(BLOCK)
     renderUpdater(TAIKO_MAINNET_CHAIN_ID, provider)
     await act(async () => undefined) // flush the initial getBlockNumber()
 
     expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK)
-    // 6 blocks per fetch: one data refresh window (~12s) at Taiko's 2s block time.
-    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.listenerOptions).toEqual({ blocksPerFetch: 6 })
+    // Cadence is owned by the wall-clock gate, so every advance of the feed means "refetch now".
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.listenerOptions).toEqual({ blocksPerFetch: 1 })
 
-    // Within the window, new blocks do not move the quantized feed.
+    // Within the refresh window, new blocks do not move the gated feed - no matter how many the
+    // chain produces.
     act(() => {
       provider.emit('block', BLOCK + 3)
+      provider.emit('block', BLOCK + 6)
+      provider.emit('block', BLOCK + 9)
     })
     expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK)
 
@@ -299,11 +208,13 @@ describe('MulticallUpdater', () => {
     })
     expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 2)
 
-    // The next steady-state advance is measured from the snapped block.
+    // The next steady-state advance happens once a full window has elapsed since the snap.
     act(() => {
-      provider.emit('block', BLOCK + 8)
+      provider.emit('block', BLOCK + 10)
     })
-    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 8)
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 2)
+    elapseWindowTo(provider, BLOCK + 12)
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 12)
   })
 
   it('keeps the dedicated mainnet feed on the Taiko mainnet cadence', async () => {
@@ -314,20 +225,20 @@ describe('MulticallUpdater', () => {
     // The "mainnet" updater (registered under ChainId.MAINNET = 1 in this fork) is fed Taiko
     // mainnet blocks and fetch cadence.
     expect(latestUpdaterProps(1)?.latestBlockNumber).toEqual(BLOCK)
-    expect(latestUpdaterProps(1)?.listenerOptions).toEqual({ blocksPerFetch: 6 })
+    expect(latestUpdaterProps(1)?.listenerOptions).toEqual({ blocksPerFetch: 1 })
     act(() => {
       fastForward(BLOCK + 2)
     })
     expect(latestUpdaterProps(1)?.latestBlockNumber).toEqual(BLOCK + 2)
   })
 
-  it('quantizes and snaps the active feed on Hoodi without touching the mainnet feed', async () => {
+  it('gates and snaps the active feed on Hoodi without touching the mainnet feed', async () => {
     const provider = new FakeProvider(BLOCK)
     renderUpdater(TAIKO_HOODI_CHAIN_ID, provider)
     await act(async () => undefined)
 
     expect(latestUpdaterProps(TAIKO_HOODI_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK)
-    expect(latestUpdaterProps(TAIKO_HOODI_CHAIN_ID)?.listenerOptions).toEqual({ blocksPerFetch: 6 })
+    expect(latestUpdaterProps(TAIKO_HOODI_CHAIN_ID)?.listenerOptions).toEqual({ blocksPerFetch: 1 })
     act(() => {
       fastForward(BLOCK + 2)
     })
@@ -342,16 +253,18 @@ describe('MulticallUpdater', () => {
 
     act(() => {
       markFetching(TAIKO_MAINNET_CHAIN_ID, ISOLATION_ACTIVE_CALL, BLOCK)
-      provider.emit('block', BLOCK + STEP)
-      provider.emit('block', BLOCK + 2 * STEP)
-      provider.emit('block', BLOCK + 3 * STEP)
     })
+    // Windows keep elapsing while the fetch is in flight: the gated feed advances, but the
+    // settled feed passed to the updater must not, or the fetch would be cancelled.
+    elapseWindowTo(provider, BLOCK + 12)
+    elapseWindowTo(provider, BLOCK + 24)
+    elapseWindowTo(provider, BLOCK + 36)
     expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK)
 
     act(() => {
       settle(TAIKO_MAINNET_CHAIN_ID, ISOLATION_ACTIVE_CALL, BLOCK)
     })
-    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 3 * STEP)
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 36)
   })
 
   it('gates the active and dedicated mainnet updater independently', async () => {
@@ -361,23 +274,23 @@ describe('MulticallUpdater', () => {
 
     act(() => {
       markFetching(TAIKO_MAINNET_CHAIN_ID, ACTIVE_CALL, BLOCK)
-      provider.emit('block', BLOCK + STEP)
     })
+    elapseWindowTo(provider, BLOCK + 12)
     expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK)
-    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + STEP)
+    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + 12)
 
     act(() => {
       settle(TAIKO_MAINNET_CHAIN_ID, ACTIVE_CALL, BLOCK)
-      markFetching(ChainId.MAINNET, MAINNET_CALL, BLOCK + STEP)
-      provider.emit('block', BLOCK + 2 * STEP)
+      markFetching(ChainId.MAINNET, MAINNET_CALL, BLOCK + 12)
     })
-    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 2 * STEP)
-    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + STEP)
+    elapseWindowTo(provider, BLOCK + 24)
+    expect(latestUpdaterProps(TAIKO_MAINNET_CHAIN_ID)?.latestBlockNumber).toEqual(BLOCK + 24)
+    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + 12)
 
     act(() => {
-      settle(ChainId.MAINNET, MAINNET_CALL, BLOCK + STEP)
+      settle(ChainId.MAINNET, MAINNET_CALL, BLOCK + 12)
     })
-    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + 2 * STEP)
+    expect(latestUpdaterProps(ChainId.MAINNET)?.latestBlockNumber).toEqual(BLOCK + 24)
   })
 
   it('remounts the active updater across a chain switch and releases the old chain on settlement', async () => {
@@ -401,7 +314,7 @@ describe('MulticallUpdater', () => {
       markFetching(CHAIN_A, SWITCH_CALL, BLOCK)
     })
 
-    const providerB = new FakeProvider(BLOCK + STEP)
+    const providerB = new FakeProvider(BLOCK + 6)
     mocked(useWeb3React).mockReturnValue({
       chainId: CHAIN_B,
       provider: providerB,

--- a/src/lib/state/multicall.tsx
+++ b/src/lib/state/multicall.tsx
@@ -1,70 +1,28 @@
 import { createMulticall, ListenerOptions } from '@uniswap/redux-multicall'
 import { ChainId } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import { blocksPerWindow, DATA_REFRESH_WINDOW_MS, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
 import { useInterfaceMulticall, useMainnetInterfaceMulticall } from 'hooks/useContract'
-import useBlockNumber, { useFastForwardedBlockNumber, useMainnetBlockNumber } from 'lib/hooks/useBlockNumber'
-import { useEffect, useMemo, useState } from 'react'
+import { useMainnetRefetchBlockNumber, useRefetchBlockNumber } from 'lib/hooks/useBlockNumber'
+import { useEffect, useState } from 'react'
 import { useAppSelector } from 'state/hooks'
 
 const multicall = createMulticall()
 
 export default multicall
 
-// The redux-multicall Updater cancels every in-flight fetch whenever the block
-// number it receives changes, so if a provider's round trip is slower than the
-// block interval (common for wallet extensions and WalletConnect, especially
-// under RPC rate limits), results are discarded before they ever land and
-// pages that block on multicall data (e.g. /pools) load forever. Advancing the
-// desired block once per data refresh window — a block count derived from the
-// chain's block time: 6 blocks at today's 2s Taiko cadence, 24 if Taiko moves
-// to 0.5s — preserves the interface's intended refresh cadence.
-// `useSettledBlockNumber` below then prevents even slower fetches from being
-// cancelled at a window boundary.
+// The redux-multicall Updater refetches every listening call whenever the block number it
+// receives advances past `blocksPerFetch`, and cancels in-flight fetches whenever it changes at
+// all — so on a chain producing a block every second or two it must not be fed the raw block
+// feed. It is fed the wall-clock-gated feed (useRefetchBlockNumber) instead, which advances at
+// most once per data refresh window (~12s) regardless of block cadence, and snaps forward when a
+// receipt for one of the user's own transactions confirms so user-relevant data (balances,
+// allowances, positions) refetches immediately instead of waiting out the window.
 //
-// `snapTo` cuts through the window: it carries the block number of a confirmed
-// receipt for one of the user's own transactions, proof that state relevant to
-// the user changed. Snapping the quantized feed to it makes dependent data
-// (balances, allowances, positions) refetch immediately instead of waiting out
-// the remainder of the window.
-//
-// The quantized value is keyed by `chainId`: block numbers from different
-// chains are not comparable, so after a chain switch the hook returns
-// undefined until the new chain's feed produces a block (which is adopted
-// directly), rather than leaking the previous chain's number to the new
-// chain's updater. Exported for testing.
-export function useQuantizedBlockNumber(
-  chainId: number | undefined,
-  blockNumber: number | undefined,
-  step: number,
-  snapTo?: number
-): number | undefined {
-  const [quantized, setQuantized] = useState<{ chainId?: number; block?: number }>({})
-  useEffect(() => {
-    if (chainId === undefined || blockNumber === undefined) return
-    setQuantized((prev) => {
-      // The first block observed for a chain is adopted directly; afterwards
-      // advance only in `step` increments, and take the new number directly if
-      // it moved backwards (reorg).
-      if (
-        prev.chainId !== chainId ||
-        prev.block === undefined ||
-        blockNumber >= prev.block + step ||
-        blockNumber < prev.block
-      ) {
-        return { chainId, block: blockNumber }
-      }
-      return prev
-    })
-  }, [chainId, blockNumber, step])
-  useEffect(() => {
-    if (chainId === undefined || snapTo === undefined) return
-    setQuantized((prev) =>
-      prev.chainId === chainId && prev.block !== undefined && snapTo <= prev.block ? prev : { chainId, block: snapTo }
-    )
-  }, [chainId, snapTo])
-  return quantized.chainId === chainId ? quantized.block : undefined
-}
+// With cadence owned by that time gate, `blocksPerFetch` must be 1: every advance of the gated
+// feed means "a window has elapsed (or a receipt landed) — refetch now". Any larger value would
+// re-introduce a block-count dependency and skip windows whenever the chain happened to produce
+// fewer blocks than that per window.
+const LISTENER_OPTIONS: ListenerOptions = { blocksPerFetch: 1 }
 
 // Keep the block given to redux-multicall stable until its current request
 // settles. The dependency cancels in-flight work when this value changes; once
@@ -97,69 +55,20 @@ function useMulticallFetching(chainId: number | undefined): boolean {
   })
 }
 
-/**
- *
- * @param chainId
- * @returns The number of blocks to wait between multicall fetches: the blocks the chain produces
- * within the app's data refresh window, so refetch cadence is constant wall time (~12s) no matter
- * how fast the chain produces blocks.
- */
-function getBlocksPerFetchForChainId(chainId: number | undefined): number {
-  // TODO(WEB-2437): See if these numbers need to be updated
-  switch (chainId) {
-    case ChainId.ARBITRUM_ONE:
-    case ChainId.OPTIMISM:
-      return 15
-    case ChainId.AVALANCHE:
-    case ChainId.BNB:
-    case ChainId.CELO:
-    case ChainId.CELO_ALFAJORES:
-      return 5
-    default:
-      // Derived from the per-chain block time table (config/chains/blockTime):
-      // 6 blocks on 2s Taiko chains, 24 at a future 0.5s cadence, 1 on
-      // Ethereum-cadence chains.
-      return blocksPerWindow(chainId, DATA_REFRESH_WINDOW_MS)
-  }
-}
-
 export function MulticallUpdater() {
   const { chainId } = useWeb3React()
-  const fastForwardedBlock = useFastForwardedBlockNumber()
-  const latestBlockNumber = useQuantizedBlockNumber(
-    chainId,
-    useBlockNumber(),
-    blocksPerWindow(chainId, DATA_REFRESH_WINDOW_MS),
-    fastForwardedBlock
-  )
+  const latestBlockNumber = useRefetchBlockNumber()
   // In this Taiko-only fork the "mainnet" feed carries Taiko mainnet blocks
-  // (see useMainnetInterfaceMulticall), so it quantizes, snaps, and fetches on
+  // (see useMainnetInterfaceMulticall), so it gates, snaps, and fetches on
   // the Taiko mainnet cadence rather than Ethereum mainnet's. Its feed is
   // always Taiko-mainnet-keyed, no matter which chain the wallet is on.
-  const latestMainnetBlockNumber = useQuantizedBlockNumber(
-    TAIKO_MAINNET_CHAIN_ID,
-    useMainnetBlockNumber(),
-    blocksPerWindow(TAIKO_MAINNET_CHAIN_ID, DATA_REFRESH_WINDOW_MS),
-    chainId === TAIKO_MAINNET_CHAIN_ID ? fastForwardedBlock : undefined
-  )
+  const latestMainnetBlockNumber = useMainnetRefetchBlockNumber()
   const isFetching = useMulticallFetching(chainId)
   const isMainnetFetching = useMulticallFetching(ChainId.MAINNET)
   const settledBlockNumber = useSettledBlockNumber(chainId, latestBlockNumber, isFetching)
   const settledMainnetBlockNumber = useSettledBlockNumber(ChainId.MAINNET, latestMainnetBlockNumber, isMainnetFetching)
   const contract = useInterfaceMulticall()
   const mainnetContract = useMainnetInterfaceMulticall()
-  const listenerOptions: ListenerOptions = useMemo(
-    () => ({
-      blocksPerFetch: getBlocksPerFetchForChainId(chainId),
-    }),
-    [chainId]
-  )
-  const mainnetListener: ListenerOptions = useMemo(
-    () => ({
-      blocksPerFetch: getBlocksPerFetchForChainId(TAIKO_MAINNET_CHAIN_ID),
-    }),
-    []
-  )
 
   return (
     <>
@@ -167,7 +76,7 @@ export function MulticallUpdater() {
         chainId={ChainId.MAINNET}
         latestBlockNumber={settledMainnetBlockNumber}
         contract={mainnetContract}
-        listenerOptions={mainnetListener}
+        listenerOptions={LISTENER_OPTIONS}
       />
       {chainId !== ChainId.MAINNET && (
         // redux-multicall stores cancellation callbacks on the updater
@@ -177,7 +86,7 @@ export function MulticallUpdater() {
           chainId={chainId}
           latestBlockNumber={settledBlockNumber}
           contract={contract}
-          listenerOptions={listenerOptions}
+          listenerOptions={LISTENER_OPTIONS}
         />
       )}
     </>

--- a/src/state/logs/hooks.ts
+++ b/src/state/logs/hooks.ts
@@ -1,6 +1,6 @@
 import type { Filter } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
-import useBlockNumber from 'lib/hooks/useBlockNumber'
+import { useRefetchBlockNumber } from 'lib/hooks/useBlockNumber'
 import { useEffect, useMemo } from 'react'
 
 import { useAppDispatch, useAppSelector } from '../hooks'
@@ -26,13 +26,15 @@ interface UseLogsResult {
 }
 
 /**
- * Returns the logs for the given filter as of the latest block, re-fetching from the library every block.
+ * Returns the logs for the given filter, re-fetched once per data refresh window (see
+ * useRefetchBlockNumber) rather than on every block.
  * @param filter The logs filter, with `fromBlock` or `toBlock` optionally specified.
  * The filter parameter should _always_ be memoized, or else will trigger constant refetching
  */
 export function useLogs(filter: Filter | undefined): UseLogsResult {
   const { chainId } = useWeb3React()
-  const blockNumber = useBlockNumber()
+  // The same feed the logs Updater fetches against, so SYNCED/SYNCING reflect the fetch cadence.
+  const blockNumber = useRefetchBlockNumber()
 
   const logs = useAppSelector((state) => state.logs)
   const dispatch = useAppDispatch()

--- a/src/state/logs/updater.ts
+++ b/src/state/logs/updater.ts
@@ -1,6 +1,6 @@
 import type { Filter } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
-import useBlockNumber from 'lib/hooks/useBlockNumber'
+import { useRefetchBlockNumber } from 'lib/hooks/useBlockNumber'
 import { useEffect, useMemo } from 'react'
 
 import { useAppDispatch, useAppSelector } from '../hooks'
@@ -12,7 +12,8 @@ export default function Updater(): null {
   const state = useAppSelector((state) => state.logs)
   const { chainId, provider } = useWeb3React()
 
-  const blockNumber = useBlockNumber()
+  // Refetch log filters once per data refresh window, not on every block.
+  const blockNumber = useRefetchBlockNumber()
 
   const filtersNeedFetch: Filter[] = useMemo(() => {
     if (!chainId || typeof blockNumber !== 'number') return []

--- a/src/state/transactions/reducer.ts
+++ b/src/state/transactions/reducer.ts
@@ -57,6 +57,7 @@ const transactionSlice = createSlice({
       } else {
         tx.lastCheckedBlockNumber = Math.max(blockNumber, tx.lastCheckedBlockNumber)
       }
+      tx.lastCheckedTime = Date.now()
     },
     finalizeTransaction(transactions, { payload: { hash, chainId, receipt } }) {
       const tx = transactions[chainId]?.[hash]

--- a/src/state/transactions/types.ts
+++ b/src/state/transactions/types.ts
@@ -204,6 +204,10 @@ export interface TransactionDetails {
   hash: string
   receipt?: SerializableTransactionReceipt
   lastCheckedBlockNumber?: number
+  // Wall-clock time of the last receipt check, used to back off re-checks of long-pending
+  // transactions independently of the chain's block cadence. Absent on transactions persisted
+  // before this field existed; treated as "never checked".
+  lastCheckedTime?: number
   addedTime: number
   confirmedTime?: number
   deadline?: number


### PR DESCRIPTION
## Description

Fixes the `/pools` (and every other multicall-backed) refetch cadence on today's ~1s-block Taiko: the previous design advanced the multicall block feed in **6-block steps**, tuned for 2s blocks, so the intended ~12s data refresh window silently became ~6s when Taiko sped up — and would shift again with any future block-time change.

Replaces block-count quantization with a **wall-clock gate**: when block N is first adopted at time T, later blocks are ignored until a block arrives at or after **T + 12s** (`DATA_REFRESH_WINDOW_MS`). The refresh cadence is now a fixed time budget at any block production rate, with no block-time configuration involved. Two events still cut through the window, because waiting would show the user stale data after their own action: a receipt for one of the user's own transactions snaps the feed forward immediately, and a reorg (lower block) is adopted immediately; both restart the window.

Sweeps the remaining block-driven refetching to the same time-based approach:

- **`lib/hooks/useBlockNumber`** — new `useRefetchBlockNumber` / `useMainnetRefetchBlockNumber` feeds, computed in `BlockNumberProvider` by a `useTimeGatedBlockNumber` hook. Also makes `fastForward` identity-stable: it previously got a new identity on every block state update, cancelling and restarting consumers' in-flight effects (e.g. the receipt retry loop) once per block event.
- **`lib/state/multicall`** — updaters consume the gated feeds; `blocksPerFetch` is now `1`, since every advance of the gated feed means "a window elapsed (or a receipt landed) — refetch now". Any larger value would re-introduce a block-count dependency and skip windows whenever the chain produced fewer blocks than that per window.
- **`lib/hooks/multicall`** — the data hooks receive the same gated feed the updater fetches against, so `valid`/`syncing` no longer compare results against a raw feed that is always ahead on a fast chain (`syncing` was effectively always `true`).
- **`useV3PositionFees`** — the `callStatic.collect` simulation was keyed on the raw feed: **one `eth_call` per block (~per second) per open position**. Now once per window.
- **`state/logs`** — `getLogs` refetching and the `SYNCED`/`SYNCING` state keyed to the gated feed.
- **transactions receipt checks** — `shouldCheck` backoff for long-pending transactions now uses a persisted wall-clock `lastCheckedTime` instead of estimating elapsed time as block count × configured block time (which drifted 2× when real block time halved). Fresh transactions are still checked on every new block event, so confirmation UX keeps tracking the chain. Old persisted transactions without the new field are treated as due and stamped on first check.
- **`usePoolTickData`** — drops the block-denominated `{ blocksPerFetch: 2 }` override; cadence comes from the gated feed.
- **`useFeeTierDistribution`** — subgraph staleness threshold converted from a raw 20-block constant to a time-denominated one (60s) translated per chain.

`REACT_APP_TAIKO_BLOCK_TIME_MS` and `blocksPerWindow` remain only for the few places that must convert a *block-number difference* into approximate wall time (subgraph staleness, permit signature margin); getting that config wrong no longer affects refetch cadence or RPC load. `TAIKO_BLOCK_TIME_SUPPORT.md` is updated accordingly (findings F3, §3 principles, §5 cutover runbook — the 0.5s cutover now requires no change for cadence).

_Relevant docs:_ `TAIKO_BLOCK_TIME_SUPPORT.md`

## Test plan

### Reproducing the error

1. Open `/pools` with a connected wallet on Taiko mainnet (~1s blocks).
2. Observe multicall refetches (and `callStatic.collect` eth_calls on a position page) firing roughly every ~6s / every block instead of the designed ~12s window, scaling with block production rate.

### QA (ie manual testing)

- [ ] `/pools` and position pages refresh data on a ~12s cadence; a swap/approval still refreshes balances/allowances immediately on confirmation (receipt snap)
- [ ] Chain switch (mainnet ↔ Hoodi) shows the new chain's data immediately (first block adopted without waiting out a window)

### Automated testing

- [x] Unit test — `useTimeGatedBlockNumber` window/snap/reorg/chain-switch semantics, provider-level `useRefetchBlockNumber` integration, `MulticallUpdater` gating under fake timers, wall-clock `shouldCheck` backoff; full suite green (121 suites / 705 tests), `tsc` and lint clean
- [x] Integration/E2E test N/A (no e2e infra for block cadence; covered by hook-level integration tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqKvf3SSkerJseeV6HDfyU)_