### PR TITLE
fix: fetch all on-chain data through the app's own RPC, not the wallet's

### DIFF
--- a/src/components/AccountDrawer/MiniPortfolio/Pools/hooks.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Pools/hooks.ts
@@ -5,7 +5,7 @@ import NFTPositionManagerJSON from '@uniswap/v3-periphery/artifacts/contracts/No
 import { useWeb3React } from '@web3-react/core'
 import { MULTICALL_ADDRESSES, NONFUNGIBLE_POSITION_MANAGER_ADDRESSES as V3NFT_ADDRESSES } from 'config/chains'
 import { isSupportedChain } from 'constants/chains'
-import { RPC_PROVIDERS } from 'constants/providers'
+import { getAppRpcProvider } from 'constants/providers'
 import { BaseContract } from 'ethers/lib/ethers'
 import { ContractInput, useUniswapPricesQuery } from 'graphql/data/__generated__/types-and-hooks'
 import { toContractInput } from 'graphql/data/util'
@@ -19,7 +19,9 @@ import { PositionInfo } from './cache'
 
 type ContractMap<T extends BaseContract> = { [key: number]: T }
 
-// Constructs a chain-to-contract map, using the wallet's provider when available
+// Constructs a chain-to-contract map, preferring the interface's own RPC providers so reads never
+// depend on the wallet's endpoint; the wallet's provider is only a fallback for chains the
+// interface has no provider for.
 function useContractMultichain<T extends BaseContract>(
   addressMap: AddressMap,
   ABI: any,
@@ -42,11 +44,7 @@ function useContractMultichain<T extends BaseContract>(
       }
 
       const provider =
-        walletProvider && walletChainId === chainId
-          ? walletProvider
-          : isSupportedChain(chainId)
-          ? RPC_PROVIDERS[chainId]
-          : undefined
+        getAppRpcProvider(chainId) ?? (walletProvider && walletChainId === chainId ? walletProvider : undefined)
       if (provider) {
         acc[chainId] = getContract(address, ABI, provider) as T
       }

--- a/src/components/AccountDrawer/MiniPortfolio/Tokens/useTaikoTokenBalances.ts
+++ b/src/components/AccountDrawer/MiniPortfolio/Tokens/useTaikoTokenBalances.ts
@@ -1,9 +1,7 @@
 import { Contract } from '@ethersproject/contracts'
 import { ChainId, Token } from '@uniswap/sdk-core'
-import { useWeb3React } from '@web3-react/core'
 import ERC20_ABI from 'abis/erc20.json'
-import { isSupportedChain, SupportedInterfaceChain } from 'constants/chains'
-import { RPC_PROVIDERS } from 'constants/providers'
+import { getAppRpcProvider } from 'constants/providers'
 import { useEffect, useState } from 'react'
 
 interface TaikoTokenBalance {
@@ -60,7 +58,6 @@ const TAIKO_HOODI_COMMON_TOKENS = [
  * Fetches token balances for common tokens on Taiko chains
  */
 export function useTaikoTokenBalances(account: string | undefined, chainId: ChainId | undefined) {
-  const { provider: walletProvider } = useWeb3React()
   const [balances, setBalances] = useState<TaikoTokenBalance[]>([])
   const [loading, setLoading] = useState(true)
 
@@ -81,9 +78,9 @@ export function useTaikoTokenBalances(account: string | undefined, chainId: Chai
     const fetchBalances = async () => {
       setLoading(true)
       try {
-        // Check if chainId is a supported chain before accessing RPC_PROVIDERS
-        const provider =
-          walletProvider || (isSupportedChain(chainId) ? RPC_PROVIDERS[chainId as SupportedInterfaceChain] : undefined)
+        // Balances are data reads: always fetch through the interface's own RPC, never the
+        // wallet's endpoint. Both reachable chains here are Taiko chains, which always have one.
+        const provider = getAppRpcProvider(chainId)
         if (!provider) {
           setLoading(false)
           return
@@ -119,7 +116,7 @@ export function useTaikoTokenBalances(account: string | undefined, chainId: Chai
     }
 
     fetchBalances()
-  }, [account, chainId, walletProvider])
+  }, [account, chainId])
 
   return { balances, loading }
 }

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -66,3 +66,14 @@ export const RPC_PROVIDERS: { [key in SupportedInterfaceChain]: StaticJsonRpcPro
   [TAIKO_MAINNET_CHAIN_ID]: new AppJsonRpcProvider(TAIKO_MAINNET_CHAIN_ID as SupportedInterfaceChain),
   [TAIKO_HOODI_CHAIN_ID]: new AppJsonRpcProvider(TAIKO_HOODI_CHAIN_ID as SupportedInterfaceChain),
 } as any
+
+/**
+ * Returns the interface's own JSON-RPC provider for a chain, if the interface has one.
+ * RPC_PROVIDERS is typed for every supported interface chain, but this Taiko-only deployment
+ * only instantiates Taiko providers, so indexing it for other chains yields undefined at
+ * runtime. This accessor makes that safe for any chainId.
+ */
+export function getAppRpcProvider(chainId: number | undefined): StaticJsonRpcProvider | undefined {
+  if (chainId === undefined) return undefined
+  return (RPC_PROVIDERS as { [chainId: number]: StaticJsonRpcProvider | undefined })[chainId]
+}

--- a/src/hooks/useContract.test.tsx
+++ b/src/hooks/useContract.test.tsx
@@ -1,0 +1,80 @@
+import { ChainId } from '@uniswap/sdk-core'
+import { useWeb3React } from '@web3-react/core'
+import ERC20_ABI from 'abis/erc20.json'
+import { TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
+import { RPC_PROVIDERS } from 'constants/providers'
+import { EventEmitter } from 'events'
+import { mocked } from 'test-utils/mocked'
+import { act, renderHook } from 'test-utils/render'
+
+import { useContract } from './useContract'
+
+const TOKEN_ADDRESS = '0xA51894664A773981C6C112C43ce576f315d5b1B6' // WETH on Taiko mainnet
+const ACCOUNT = '0x0000000000000000000000000000000000000001'
+
+// Mimics the interface's own RPC provider closely enough for ethers' Contract and the ambient
+// BlockNumberProvider mounted by the test wrapper.
+class FakeAppProvider extends EventEmitter {
+  readonly _isProvider = true
+  async getBlockNumber() {
+    return 1
+  }
+}
+
+// Mimics a connected wallet's provider; getSigner mirrors ethers' JsonRpcProvider shape closely
+// enough for getContract's signer path.
+class FakeWalletProvider extends FakeAppProvider {
+  getSigner(account: string) {
+    return {
+      connectUnchecked: () => ({ _isSigner: true, provider: this, getAddress: async () => account }),
+    }
+  }
+}
+
+function mockWeb3(chainId: number, provider: FakeWalletProvider, account?: string) {
+  mocked(useWeb3React).mockReturnValue({ chainId, provider, account } as unknown as ReturnType<typeof useWeb3React>)
+}
+
+describe('useContract', () => {
+  let appProvider: FakeAppProvider
+  let walletProvider: FakeWalletProvider
+
+  beforeEach(() => {
+    appProvider = new FakeAppProvider()
+    walletProvider = new FakeWalletProvider()
+    // Each jest test file gets its own module registry, so this mutation cannot leak into other
+    // test files.
+    ;(RPC_PROVIDERS as Record<number, unknown>)[TAIKO_MAINNET_CHAIN_ID] = appProvider
+  })
+
+  it('binds read-only contracts to the app RPC provider, not the wallet', async () => {
+    mockWeb3(TAIKO_MAINNET_CHAIN_ID, walletProvider, ACCOUNT)
+    const { result } = renderHook(() => useContract(TOKEN_ADDRESS, ERC20_ABI, false))
+    await act(async () => undefined) // flush the ambient block feed's initial getBlockNumber()
+    expect(result.current?.provider).toBe(appProvider)
+    expect(result.current?.signer).toBeNull()
+  })
+
+  it('binds signer-capable contracts to the app RPC provider while no account is connected', async () => {
+    mockWeb3(TAIKO_MAINNET_CHAIN_ID, walletProvider, undefined)
+    const { result } = renderHook(() => useContract(TOKEN_ADDRESS, ERC20_ABI, true))
+    await act(async () => undefined)
+    expect(result.current?.provider).toBe(appProvider)
+    expect(result.current?.signer).toBeNull()
+  })
+
+  it('keeps signer-attached contracts on the wallet provider', async () => {
+    mockWeb3(TAIKO_MAINNET_CHAIN_ID, walletProvider, ACCOUNT)
+    const { result } = renderHook(() => useContract(TOKEN_ADDRESS, ERC20_ABI, true))
+    await act(async () => undefined)
+    expect(result.current?.signer).toBeTruthy()
+    expect(result.current?.provider).toBe(walletProvider)
+  })
+
+  it('falls back to the wallet provider for chains the interface has no provider for', async () => {
+    mockWeb3(ChainId.MAINNET, walletProvider, undefined)
+    const { result } = renderHook(() => useContract(TOKEN_ADDRESS, ERC20_ABI, false))
+    await act(async () => undefined)
+    expect(result.current?.provider).toBe(walletProvider)
+  })
+})

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -26,7 +26,7 @@ import {
   TICK_LENS_ADDRESSES,
   V3_MIGRATOR_ADDRESSES,
 } from 'config/chains'
-import { RPC_PROVIDERS } from 'constants/providers'
+import { getAppRpcProvider, RPC_PROVIDERS } from 'constants/providers'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
 import { useEffect, useMemo } from 'react'
 import { NonfungiblePositionManager, TickLens, UniswapInterfaceMulticall } from 'types/v3'
@@ -49,13 +49,19 @@ export function useContract<T extends Contract = Contract>(
   const { provider, account, chainId } = useWeb3React()
 
   return useMemo(() => {
-    if (!addressOrAddressMap || !ABI || !provider || !chainId) return null
+    if (!addressOrAddressMap || !ABI || !chainId) return null
     let address: string | undefined
     if (typeof addressOrAddressMap === 'string') address = addressOrAddressMap
     else address = addressOrAddressMap[chainId]
     if (!address) return null
+    // Only signing needs the connected wallet. Reads go through the interface's own RPC when it
+    // has a provider for the chain, so data fetching never depends on the wallet's endpoint; the
+    // wallet's provider remains the fallback for chains the interface has no provider for.
+    const signerAccount = withSignerIfPossible && account ? account : undefined
+    const contractProvider = signerAccount ? provider : getAppRpcProvider(chainId) ?? provider
+    if (!contractProvider) return null
     try {
-      return getContract(address, ABI, provider, withSignerIfPossible && account ? account : undefined)
+      return getContract(address, ABI, contractProvider, signerAccount)
     } catch (error) {
       console.error('Failed to get contract', error)
       return null
@@ -64,20 +70,17 @@ export function useContract<T extends Contract = Contract>(
 }
 
 function useMainnetContract<T extends Contract = Contract>(address: string | undefined, ABI: any): T | null {
-  const { chainId } = useWeb3React()
-  const isTaikoMainnet = chainId === TAIKO_MAINNET_CHAIN_ID
-  const contract = useContract(isTaikoMainnet ? address : undefined, ABI, false)
+  // Always reads through the interface's own Taiko mainnet RPC: this feed must be available and
+  // wallet-independent no matter which chain (if any) the wallet is on.
   return useMemo(() => {
-    if (isTaikoMainnet) return contract
     if (!address) return null
-    const provider = RPC_PROVIDERS[TAIKO_MAINNET_CHAIN_ID]
     try {
-      return getContract(address, ABI, provider)
+      return getContract(address, ABI, RPC_PROVIDERS[TAIKO_MAINNET_CHAIN_ID])
     } catch (error) {
       console.error('Failed to get Taiko mainnet contract', error)
       return null
     }
-  }, [address, ABI, contract, isTaikoMainnet]) as T
+  }, [address, ABI]) as T
 }
 
 export function useV2MigratorContract() {

--- a/src/lib/hooks/transactions/updater.test.tsx
+++ b/src/lib/hooks/transactions/updater.test.tsx
@@ -2,6 +2,7 @@ import { TransactionReceipt } from '@ethersproject/abstract-provider'
 import { ChainId } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
+import { RPC_PROVIDERS } from 'constants/providers'
 import { EventEmitter } from 'events'
 import { useCallback, useState } from 'react'
 import { TransactionDetails } from 'state/transactions/types'
@@ -145,6 +146,9 @@ describe('Updater receipt polling', () => {
       chainId: TAIKO_MAINNET_CHAIN_ID,
       provider,
     } as unknown as ReturnType<typeof useWeb3React>)
+    // The block feed and receipt polling read through the interface's own RPC providers rather
+    // than the wallet's, so the fake must be installed there too (per-file module registry).
+    ;(RPC_PROVIDERS as Record<number, unknown>)[TAIKO_MAINNET_CHAIN_ID] = provider
 
     const onCheck = jest.fn()
     const onReceipt = jest.fn()

--- a/src/lib/hooks/transactions/updater.test.tsx
+++ b/src/lib/hooks/transactions/updater.test.tsx
@@ -99,6 +99,27 @@ describe('Updater receipt polling', () => {
     }
   }
 
+  // A wallet provider that records every use: with an app RPC provider installed for the chain,
+  // neither the block feed nor receipt polling may ever touch the wallet.
+  class ForbiddenWalletProvider {
+    readonly _isProvider = true
+    readonly calls: string[] = []
+    getTransactionReceipt() {
+      this.calls.push('getTransactionReceipt')
+      return Promise.reject(new Error('wallet RPC must not serve reads'))
+    }
+    getBlockNumber() {
+      this.calls.push('getBlockNumber')
+      return Promise.reject(new Error('wallet RPC must not serve reads'))
+    }
+    on(event: string) {
+      this.calls.push(`on:${event}`)
+    }
+    removeListener(event: string) {
+      this.calls.push(`removeListener:${event}`)
+    }
+  }
+
   // Feeds Updater a pending map and, like the transactions reducer, marks the transaction
   // finalized when its receipt arrives so it is not re-checked.
   function Harness({
@@ -142,12 +163,14 @@ describe('Updater receipt polling', () => {
     // The transaction confirms on-chain after two polls - long before the next block event,
     // which never arrives in this test.
     provider.getTransactionReceipt.mockResolvedValueOnce(null).mockResolvedValueOnce(null).mockResolvedValue(receipt)
+    // The wallet's provider is deliberately distinct from the fake: the block feed and receipt
+    // polling must read through the interface's own RPC provider (installed below), never the
+    // wallet's (per-file module registry, so the mutation cannot leak into other files).
+    const walletProvider = new ForbiddenWalletProvider()
     mocked(useWeb3React).mockReturnValue({
       chainId: TAIKO_MAINNET_CHAIN_ID,
-      provider,
+      provider: walletProvider,
     } as unknown as ReturnType<typeof useWeb3React>)
-    // The block feed and receipt polling read through the interface's own RPC providers rather
-    // than the wallet's, so the fake must be installed there too (per-file module registry).
     ;(RPC_PROVIDERS as Record<number, unknown>)[TAIKO_MAINNET_CHAIN_ID] = provider
 
     const onCheck = jest.fn()
@@ -161,6 +184,8 @@ describe('Updater receipt polling', () => {
     expect(onReceipt).toHaveBeenCalledTimes(1)
     expect(onReceipt).toHaveBeenCalledWith({ chainId: TAIKO_MAINNET_CHAIN_ID, hash: HASH, receipt })
     expect(onCheck).not.toHaveBeenCalled()
+    // The wallet's endpoint served nothing: every read went through the app's own provider.
+    expect(walletProvider.calls).toEqual([])
   })
 
   it('gives up until the next block event on chains without fast retry options', async () => {

--- a/src/lib/hooks/transactions/updater.tsx
+++ b/src/lib/hooks/transactions/updater.tsx
@@ -7,6 +7,7 @@ import {
   TAIKO_HOODI_CHAIN_ID,
   TAIKO_MAINNET_CHAIN_ID,
 } from 'config/chains'
+import { getAppRpcProvider } from 'constants/providers'
 import useCurrentBlockTimestamp from 'hooks/useCurrentBlockTimestamp'
 import useBlockNumber, { useFastForwardBlockNumber } from 'lib/hooks/useBlockNumber'
 import ms from 'ms'
@@ -69,7 +70,10 @@ interface UpdaterProps {
 }
 
 export default function Updater({ pendingTransactions, onCheck, onReceipt }: UpdaterProps): null {
-  const { account, chainId, provider } = useWeb3React()
+  const { account, chainId, provider: walletProvider } = useWeb3React()
+  // Receipts are data reads: poll them through the interface's own RPC when it has a provider
+  // for the chain, so confirmation tracking never depends on the wallet's endpoint.
+  const provider = getAppRpcProvider(chainId) ?? walletProvider
 
   const lastBlockNumber = useBlockNumber()
   const fastForwardBlockNumber = useFastForwardBlockNumber()

--- a/src/lib/hooks/useBlockNumber.test.tsx
+++ b/src/lib/hooks/useBlockNumber.test.tsx
@@ -23,11 +23,41 @@ class FakeProvider extends EventEmitter {
   }
 }
 
+// A wallet provider that records every use: the block feed must come from the interface's own
+// RPC provider, so any call against the wallet is a regression (asserted in afterEach).
+class ForbiddenWalletProvider {
+  readonly calls: string[] = []
+  getBlockNumber() {
+    this.calls.push('getBlockNumber')
+    return Promise.reject(new Error('wallet RPC must not serve reads'))
+  }
+  on(event: string) {
+    this.calls.push(`on:${event}`)
+  }
+  removeListener(event: string) {
+    this.calls.push(`removeListener:${event}`)
+  }
+}
+
+const walletProviders: ForbiddenWalletProvider[] = []
+afterEach(() => {
+  const calls = walletProviders.flatMap((wallet) => wallet.calls)
+  walletProviders.length = 0
+  if (calls.length) {
+    throw new Error(`wallet provider was used for reads: ${calls.join(', ')}`)
+  }
+})
+
 function mockChain(chainId: number, provider: FakeProvider) {
-  mocked(useWeb3React).mockReturnValue({ chainId, provider } as unknown as ReturnType<typeof useWeb3React>)
-  // The block feed reads through the interface's own RPC providers rather than the wallet's, so
-  // the fake must be installed there too. Each jest test file gets its own module registry, so
-  // this mutation cannot leak into other test files.
+  // The wallet's provider is deliberately distinct from the fake feed: reads must flow through
+  // the interface's own RPC provider (installed below), never the wallet's. Each jest test file
+  // gets its own module registry, so the RPC_PROVIDERS mutation cannot leak into other files.
+  const walletProvider = new ForbiddenWalletProvider()
+  walletProviders.push(walletProvider)
+  mocked(useWeb3React).mockReturnValue({
+    chainId,
+    provider: walletProvider,
+  } as unknown as ReturnType<typeof useWeb3React>)
   ;(RPC_PROVIDERS as Record<number, unknown>)[chainId] = provider
 }
 

--- a/src/lib/hooks/useBlockNumber.test.tsx
+++ b/src/lib/hooks/useBlockNumber.test.tsx
@@ -1,5 +1,6 @@
 import { useWeb3React } from '@web3-react/core'
 import { TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
+import { RPC_PROVIDERS } from 'constants/providers'
 import { EventEmitter } from 'events'
 import { mocked } from 'test-utils/mocked'
 import { act, renderHook } from 'test-utils/render'
@@ -24,6 +25,10 @@ class FakeProvider extends EventEmitter {
 
 function mockChain(chainId: number, provider: FakeProvider) {
   mocked(useWeb3React).mockReturnValue({ chainId, provider } as unknown as ReturnType<typeof useWeb3React>)
+  // The block feed reads through the interface's own RPC providers rather than the wallet's, so
+  // the fake must be installed there too. Each jest test file gets its own module registry, so
+  // this mutation cannot leak into other test files.
+  ;(RPC_PROVIDERS as Record<number, unknown>)[chainId] = provider
 }
 
 describe('BlockNumberProvider', () => {

--- a/src/lib/hooks/useBlockNumber.tsx
+++ b/src/lib/hooks/useBlockNumber.tsx
@@ -1,6 +1,6 @@
 import { useWeb3React } from '@web3-react/core'
 import { TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
-import { RPC_PROVIDERS } from 'constants/providers'
+import { getAppRpcProvider, RPC_PROVIDERS } from 'constants/providers'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
@@ -47,7 +47,11 @@ export function useFastForwardedBlockNumber(): number | undefined {
 }
 
 export function BlockNumberProvider({ children }: { children: ReactNode }) {
-  const { chainId: activeChainId, provider } = useWeb3React()
+  const { chainId: activeChainId, provider: walletProvider } = useWeb3React()
+  // Blocks are data reads: watch them through the interface's own RPC when it has a provider for
+  // the active chain, so the feed never depends on the wallet's endpoint. The wallet's provider
+  // remains the fallback for chains the interface has no provider for.
+  const provider = getAppRpcProvider(activeChainId) ?? walletProvider
   const [{ chainId, block, mainnetBlock }, setChainBlock] = useState<{
     chainId?: number
     block?: number

--- a/src/lib/state/multicall.test.tsx
+++ b/src/lib/state/multicall.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react'
 import { ChainId } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { TAIKO_HOODI_CHAIN_ID, TAIKO_MAINNET_CHAIN_ID } from 'config/chains'
+import { RPC_PROVIDERS } from 'constants/providers'
 import { EventEmitter } from 'events'
 import { useFastForwardBlockNumber } from 'lib/hooks/useBlockNumber'
 import { useEffect, useState } from 'react'
@@ -266,6 +267,9 @@ describe('MulticallUpdater', () => {
 
   function renderUpdater(chainId: number, provider: FakeProvider) {
     mocked(useWeb3React).mockReturnValue({ chainId, provider } as unknown as ReturnType<typeof useWeb3React>)
+    // The block feed reads through the interface's own RPC providers rather than the wallet's,
+    // so the fake must be installed there too (per-file module registry, cannot leak).
+    ;(RPC_PROVIDERS as Record<number, unknown>)[chainId] = provider
     return render(updaterTree())
   }
 
@@ -406,6 +410,7 @@ describe('MulticallUpdater', () => {
       chainId: CHAIN_B,
       provider: providerB,
     } as unknown as ReturnType<typeof useWeb3React>)
+    ;(RPC_PROVIDERS as Record<number, unknown>)[CHAIN_B] = providerB
     view.rerender(updaterTree())
     await act(async () => undefined)
 
@@ -416,6 +421,7 @@ describe('MulticallUpdater', () => {
       chainId: CHAIN_A,
       provider: providerA,
     } as unknown as ReturnType<typeof useWeb3React>)
+    ;(RPC_PROVIDERS as Record<number, unknown>)[CHAIN_A] = providerA
     view.rerender(updaterTree())
     await act(async () => undefined)
     expect(latestUpdaterProps(CHAIN_A)?.latestBlockNumber).toBeUndefined()

--- a/src/lib/state/multicall.test.tsx
+++ b/src/lib/state/multicall.test.tsx
@@ -186,6 +186,25 @@ describe('MulticallUpdater', () => {
     }
   }
 
+  // A wallet provider that records every use: the block feed driving the updaters must come
+  // from the interface's own RPC providers, so any call against the wallet is a regression
+  // (asserted in afterEach).
+  class ForbiddenWalletProvider {
+    readonly calls: string[] = []
+    getBlockNumber() {
+      this.calls.push('getBlockNumber')
+      return Promise.reject(new Error('wallet RPC must not serve reads'))
+    }
+    on(event: string) {
+      this.calls.push(`on:${event}`)
+    }
+    removeListener(event: string) {
+      this.calls.push(`removeListener:${event}`)
+    }
+  }
+
+  const walletProviders: ForbiddenWalletProvider[] = []
+
   // Far above any real Taiko block number, so the ambient mainnet-block fetch
   // (swallowed in tests) can never outrank the fake feed.
   const BLOCK = 1_000_000_100
@@ -235,6 +254,12 @@ describe('MulticallUpdater', () => {
       )
     })
     updaterSpy.mockRestore()
+    // No read in any test may have touched a wallet provider.
+    const walletCalls = walletProviders.flatMap((wallet) => wallet.calls)
+    walletProviders.length = 0
+    if (walletCalls.length) {
+      throw new Error(`wallet provider was used for reads: ${walletCalls.join(', ')}`)
+    }
   })
 
   function markFetching(chainId: number, call: typeof ACTIVE_CALL, blockNumber: number) {
@@ -265,11 +290,21 @@ describe('MulticallUpdater', () => {
     return call?.[0]
   }
 
-  function renderUpdater(chainId: number, provider: FakeProvider) {
-    mocked(useWeb3React).mockReturnValue({ chainId, provider } as unknown as ReturnType<typeof useWeb3React>)
-    // The block feed reads through the interface's own RPC providers rather than the wallet's,
-    // so the fake must be installed there too (per-file module registry, cannot leak).
+  function mockChain(chainId: number, provider: FakeProvider) {
+    // The wallet's provider is deliberately distinct from the fake feed: reads must flow through
+    // the interface's own RPC provider (installed below), never the wallet's (per-file module
+    // registry, so the mutation cannot leak into other files).
+    const walletProvider = new ForbiddenWalletProvider()
+    walletProviders.push(walletProvider)
+    mocked(useWeb3React).mockReturnValue({
+      chainId,
+      provider: walletProvider,
+    } as unknown as ReturnType<typeof useWeb3React>)
     ;(RPC_PROVIDERS as Record<number, unknown>)[chainId] = provider
+  }
+
+  function renderUpdater(chainId: number, provider: FakeProvider) {
+    mockChain(chainId, provider)
     return render(updaterTree())
   }
 
@@ -406,22 +441,14 @@ describe('MulticallUpdater', () => {
     })
 
     const providerB = new FakeProvider(BLOCK + STEP)
-    mocked(useWeb3React).mockReturnValue({
-      chainId: CHAIN_B,
-      provider: providerB,
-    } as unknown as ReturnType<typeof useWeb3React>)
-    ;(RPC_PROVIDERS as Record<number, unknown>)[CHAIN_B] = providerB
+    mockChain(CHAIN_B, providerB)
     view.rerender(updaterTree())
     await act(async () => undefined)
 
     expect(mounted).toContain(CHAIN_B)
     expect(unmounted).toContain(CHAIN_A)
 
-    mocked(useWeb3React).mockReturnValue({
-      chainId: CHAIN_A,
-      provider: providerA,
-    } as unknown as ReturnType<typeof useWeb3React>)
-    ;(RPC_PROVIDERS as Record<number, unknown>)[CHAIN_A] = providerA
+    mockChain(CHAIN_A, providerA)
     view.rerender(updaterTree())
     await act(async () => undefined)
     expect(latestUpdaterProps(CHAIN_A)?.latestBlockNumber).toBeUndefined()

--- a/src/state/logs/updater.ts
+++ b/src/state/logs/updater.ts
@@ -1,5 +1,6 @@
 import type { Filter } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
+import { getAppRpcProvider } from 'constants/providers'
 import useBlockNumber from 'lib/hooks/useBlockNumber'
 import { useEffect, useMemo } from 'react'
 
@@ -10,7 +11,10 @@ import { isHistoricalLog, keyToFilter } from './utils'
 export default function Updater(): null {
   const dispatch = useAppDispatch()
   const state = useAppSelector((state) => state.logs)
-  const { chainId, provider } = useWeb3React()
+  const { chainId, provider: walletProvider } = useWeb3React()
+  // Logs are data reads: fetch them through the interface's own RPC when it has a provider for
+  // the chain, so they never depend on the wallet's endpoint.
+  const provider = getAppRpcProvider(chainId) ?? walletProvider
 
   const blockNumber = useBlockNumber()
 

--- a/src/state/signatures/updater.tsx
+++ b/src/state/signatures/updater.tsx
@@ -1,6 +1,7 @@
 import { TradeType } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { DEFAULT_TXN_DISMISS_MS, L2_TXN_DISMISS_MS } from 'constants/misc'
+import { getAppRpcProvider } from 'constants/providers'
 import { UniswapXBackendOrder, UniswapXOrderStatus } from 'lib/hooks/orders/types'
 import OrderUpdater from 'lib/hooks/orders/updater'
 import { useCallback, useMemo } from 'react'
@@ -47,7 +48,9 @@ export default function Updater() {
           }
         }
         // Wait to update a filled order until the on-chain tx is available.
-        provider?.getTransactionReceipt(update.txHash).then((receipt) => {
+        // The receipt is a data read, so prefer the interface's own RPC over the wallet's.
+        const receiptProvider = getAppRpcProvider(updatedOrder.chainId) ?? provider
+        receiptProvider?.getTransactionReceipt(update.txHash).then((receipt) => {
           dispatch(
             addTransaction({
               chainId: updatedOrder.chainId,


### PR DESCRIPTION
## Description

Routes every app-initiated on-chain read through the interface's own RPC providers (`rpc.mainnet.taiko.xyz` / `rpc.hoodi.taiko.xyz`) instead of the connected wallet's provider. Previously, once MetaMask/Rabby was connected, the bulk of interactive reads — all redux-multicall state (balances, allowances, pool state, positions), the block-number feed, transaction-receipt polling, and log fetching — went through the wallet's configured endpoint. Signing, transaction sending, and pre-send gas estimation stay on the wallet, which is the only thing that still needs it.

Changes:

- `useContract` builds read-only contract instances (no signer attached) from the app's own provider; the wallet's provider is used only when a signer must be attached, and as a fallback for chains the app has no provider for. This single seam moves the entire multicall universe to `rpc.mainnet.taiko.xyz`.
- `useMainnetContract` always reads through the app's Taiko-mainnet provider, no matter which chain the wallet is on (it previously used the wallet's provider whenever the wallet was on Taiko mainnet).
- `BlockNumberProvider` watches blocks through the app's provider for the active chain.
- The transaction updater polls receipts, the signatures updater fetches fill receipts, and the logs updater fetches logs through the app's provider.
- The mini-portfolio hooks (`useContractMultichain`, `useTaikoTokenBalances`) prefer the app's providers instead of preferring the wallet's.
- Adds `getAppRpcProvider(chainId)`, an undefined-safe accessor for `RPC_PROVIDERS`, whose type claims every supported chain but which only instantiates Taiko providers at runtime.

With no wallet connected, behavior is unchanged (reads already used these providers via the network connector, just wrapped in extra layers).

_Relevant docs:_ `TAIKO_BLOCK_TIME_SUPPORT.md` (the 12s poll cadence assumptions this relies on)

## Test plan

### QA (ie manual testing)

- [ ] With a wallet connected on Taiko mainnet (ideally with a custom/broken RPC configured in the wallet), verify balances, pool data, and swap quotes load, and that a swap still prompts/signs/confirms in the wallet
- [ ] Verify the app works with no wallet connected

### Automated testing

- [x] Unit test — the provider-routing suites (`useBlockNumber`, `multicall`, transactions `updater`) give the wallet a distinct recording provider and fail if any read touches it, and `useContract.test.tsx` verifies the read/signer split directly (read-only → app provider; signer-attached → wallet; no-app-provider chains → wallet fallback). Mutation-checked: flipping the implementation back to wallet-first fails all four suites (13 tests). Full suite passes (122 suites, 712 tests).
- [x] Integration/E2E test N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015k8uEZrMTaVxQ4aznsfsRW