### PR TITLE
chore: point Taiko subgraph URLs at Goldsky release tags

### DIFF
--- a/.env
+++ b/.env
@@ -10,9 +10,9 @@ REACT_APP_WALLET_CONNECT_PROJECT_ID="c6c9bacd35afa3eb9e6cccf6d8464395"
 REACT_APP_TAIKO_CHAIN="mainnet"
 
 # Taiko Mainnet Subgraph URLs (Goldsky)
-REACT_APP_TAIKO_MAINNET_SUBGRAPH_TOKENS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/v3-tokens-taiko/136dd59/gn"
-REACT_APP_TAIKO_MAINNET_SUBGRAPH_POOLS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko/136dd59/gn"
+REACT_APP_TAIKO_MAINNET_SUBGRAPH_TOKENS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/v3-tokens-taiko/mainnet/gn"
+REACT_APP_TAIKO_MAINNET_SUBGRAPH_POOLS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko/mainnet/gn"
 
 # Taiko Hoodi Subgraph URLs (Goldsky)
-REACT_APP_TAIKO_HOODI_SUBGRAPH_TOKENS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/v3-tokens-taiko-hoodi-testnet/6050309/gn"
-REACT_APP_TAIKO_HOODI_SUBGRAPH_POOLS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko-hoodi-testnet/6050309/gn"
+REACT_APP_TAIKO_HOODI_SUBGRAPH_TOKENS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/v3-tokens-taiko-hoodi-testnet/testnet/gn"
+REACT_APP_TAIKO_HOODI_SUBGRAPH_POOLS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko-hoodi-testnet/testnet/gn"

--- a/.env.production
+++ b/.env.production
@@ -10,9 +10,9 @@ REACT_APP_WALLET_CONNECT_PROJECT_ID="c6c9bacd35afa3eb9e6cccf6d8464395"
 REACT_APP_TAIKO_CHAIN="mainnet"
 
 # Taiko Mainnet Subgraph URLs (Goldsky)
-REACT_APP_TAIKO_MAINNET_SUBGRAPH_TOKENS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/v3-tokens-taiko/136dd59/gn"
-REACT_APP_TAIKO_MAINNET_SUBGRAPH_POOLS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko/136dd59/gn"
+REACT_APP_TAIKO_MAINNET_SUBGRAPH_TOKENS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/v3-tokens-taiko/mainnet/gn"
+REACT_APP_TAIKO_MAINNET_SUBGRAPH_POOLS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko/mainnet/gn"
 
 # Taiko Hoodi Subgraph URLs (Goldsky)
-REACT_APP_TAIKO_HOODI_SUBGRAPH_TOKENS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/v3-tokens-taiko-hoodi-testnet/6050309/gn"
-REACT_APP_TAIKO_HOODI_SUBGRAPH_POOLS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko-hoodi-testnet/6050309/gn"
+REACT_APP_TAIKO_HOODI_SUBGRAPH_TOKENS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/v3-tokens-taiko-hoodi-testnet/testnet/gn"
+REACT_APP_TAIKO_HOODI_SUBGRAPH_POOLS="https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko-hoodi-testnet/testnet/gn"

--- a/src/graphql/thegraph/apollo.ts
+++ b/src/graphql/thegraph/apollo.ts
@@ -15,10 +15,10 @@ const CHAIN_SUBGRAPH_URL: Record<number, string> = {
   // Taiko subgraphs configured via environment variables
   [TAIKO_MAINNET_CHAIN_ID]:
     process.env.REACT_APP_TAIKO_MAINNET_SUBGRAPH_POOLS ||
-    'https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko/136dd59/gn',
+    'https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko/mainnet/gn',
   [TAIKO_HOODI_CHAIN_ID]:
     process.env.REACT_APP_TAIKO_HOODI_SUBGRAPH_POOLS ||
-    'https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko-hoodi-testnet/7060ecc/gn',
+    'https://api.goldsky.com/api/public/project_clz85cxrvng3n01ughcv5e7hg/subgraphs/uniswap-v3-taiko-hoodi-testnet/testnet/gn',
 }
 
 const httpLink = new HttpLink({ uri: CHAIN_SUBGRAPH_URL[ChainId.MAINNET] })


### PR DESCRIPTION
## Summary

The Taiko pool and token endpoints were pinned to specific Goldsky deployment versions (`136dd59`, `6050309`). Every subgraph release therefore required editing these URLs by hand, and the frontend kept serving the older graph until someone did.

This points all four at stable per-network tags, so a subgraph release becomes a tag move on Goldsky with **no frontend change**.

| Variable | Before | After |
| --- | --- | --- |
| `REACT_APP_TAIKO_MAINNET_SUBGRAPH_POOLS` | `uniswap-v3-taiko/136dd59` | `uniswap-v3-taiko/mainnet` |
| `REACT_APP_TAIKO_MAINNET_SUBGRAPH_TOKENS` | `v3-tokens-taiko/136dd59` | `v3-tokens-taiko/mainnet` |
| `REACT_APP_TAIKO_HOODI_SUBGRAPH_POOLS` | `uniswap-v3-taiko-hoodi-testnet/6050309` | `uniswap-v3-taiko-hoodi-testnet/testnet` |
| `REACT_APP_TAIKO_HOODI_SUBGRAPH_TOKENS` | `v3-tokens-taiko-hoodi-testnet/6050309` | `v3-tokens-taiko-hoodi-testnet/testnet` |

## Unblocks #57

#57 lists updating the two `..._SUBGRAPH_POOLS` variables as its deployment dependency. The pool tags now resolve to `f4eb0c8`, which carries the `Position` entity from taikoxyz/uniswap-v3-subgraph#7. The previously pinned version cannot answer `positions` queries at all — it returns `Type 'Query' has no field 'positions'`.

This is safe to land before #57: the new deployment is a superset of the old schema, so existing pool and token queries are unaffected, and #57 falls back to RPC when `positions` is unavailable.

## Drive-by fix

The Hoodi fallback in `apollo.ts` pointed at `7060ecc` while `.env` used `6050309` — two different versions for the same network. Both now resolve to the same tag.

## Verification

Tags created on Goldsky and each endpoint queried directly:

```
OK   uniswap-v3-taiko/mainnet:                3 pools, 3 positions
OK   uniswap-v3-taiko-hoodi-testnet/testnet:  3 pools, 3 positions
OK   v3-tokens-taiko/mainnet:                 3 tokens
OK   v3-tokens-taiko-hoodi-testnet/testnet:   3 tokens
```

Every tag was gated on `healthy` + `Synced: 100%` before creation, using the guard added in taikoxyz/uniswap-v3-subgraph#8.

`tsc --noEmit` reports 40 pre-existing errors on both this branch and `main` — identical counts, none in `apollo.ts`. They stem from missing codegen artifacts (`abis/types`, `locales/en-US`) and are unrelated to this change.

## Note for deployment

Vercel env vars on `mainnet__uniswap-interface` and `hoodi__uniswap-interface` override these repo values in production and must be updated separately for this to take effect on swap.taiko.xyz and swap.hoodi.taiko.xyz.